### PR TITLE
[#54, #45] feat: API 전반에 JWT 기반 사용자 인증 적용

### DIFF
--- a/src/main/java/com/issueDive/controller/AuthController.java
+++ b/src/main/java/com/issueDive/controller/AuthController.java
@@ -2,14 +2,10 @@ package com.issueDive.controller;
 
 import com.issueDive.dto.*;
 import com.issueDive.service.UserService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,7 +18,7 @@ import com.issueDive.util.JwtUtil;
 @RequiredArgsConstructor
 public class AuthController {
     private final UserService userService;
-    private final AuthenticationManager authenticationManager;
+    // private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
 
     /**

--- a/src/main/java/com/issueDive/controller/CommentController.java
+++ b/src/main/java/com/issueDive/controller/CommentController.java
@@ -1,11 +1,17 @@
 package com.issueDive.controller;
 
 import com.issueDive.dto.*;
+import com.issueDive.entity.User;
+import com.issueDive.exception.UserNotFoundException;
+import com.issueDive.repository.UserRepository;
 import com.issueDive.service.CommentService;
+import com.issueDive.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,6 +21,7 @@ import java.util.List;
 @RequestMapping("/issues/{issueId}/comments")
 public class CommentController {
     private final CommentService commentService;
+    private final UserService userService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<CommentResponse>>> getComment(@PathVariable Long issueId){
@@ -23,29 +30,33 @@ public class CommentController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<CommentResponse>> createComment(@PathVariable Long issueId, @RequestBody @Valid CreateCommentRequest request
-//                                                        ,@RequestHeader("X-USER-ID") Long userId){
-    ){
-        Long userId = 1L; // 임시 사용자 ID // JWT 기능 구현 완료 시 변경
-        CommentResponse created = commentService.createComment(issueId, request, userId);
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long issueId,
+            @RequestBody @Valid CreateCommentRequest request,
+            @AuthenticationPrincipal UserDetails userDetails){
+        UserResponseDTO user = userService.findUserByEmail(userDetails.getUsername());
+        CommentResponse created = commentService.createComment(issueId, request, user.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(created));
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(@PathVariable Long issueId, @PathVariable Long commentId, @RequestBody @Valid UpdateCommentRequest request
-//            , @RequestHeader("X-USER-ID") Long userId){
-    ){
-        Long userId = 1L; // 임시 사용자 ID // JWT 기능 구현 완료 시 변경
-        CommentResponse updated = commentService.updateComment(issueId, commentId, request, userId);
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @PathVariable Long issueId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid UpdateCommentRequest request,
+            @AuthenticationPrincipal UserDetails userDetails){
+        UserResponseDTO user = userService.findUserByEmail(userDetails.getUsername());
+        CommentResponse updated = commentService.updateComment(issueId, commentId, request, user.getId());
         return ResponseEntity.ok(ApiResponse.ok(updated));
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable Long issueId, @PathVariable Long commentId
-//            , @RequestHeader("X-USER-ID") Long userId){
-    ){
-        Long userId = 1L; // 임시 사용자 ID // JWT 기능 구현 완료 시 변경
-        commentService.deleteComment(issueId, commentId, userId);
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Long issueId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails){
+        UserResponseDTO user = userService.findUserByEmail(userDetails.getUsername());
+        commentService.deleteComment(issueId, commentId, user.getId());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/issueDive/controller/IssueController.java
+++ b/src/main/java/com/issueDive/controller/IssueController.java
@@ -1,12 +1,18 @@
 package com.issueDive.controller;
 
 import com.issueDive.dto.*;
+import com.issueDive.entity.User;
+import com.issueDive.exception.UserNotFoundException;
+import com.issueDive.repository.UserRepository;
 import com.issueDive.service.IssueService;
+import com.issueDive.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -17,6 +23,7 @@ import java.util.Map;
 public class IssueController {
 
     private final IssueService issueService;
+    private final UserService userService;
 
     /**
      * Create
@@ -24,9 +31,11 @@ public class IssueController {
      * @return 공통 응답 포맷 + 생성된 이슈 dto
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<IssueResponse>> createIssue(@RequestBody CreateIssueRequest request) {
-        Long currentUserId = 1L; // 임시, TODO: 로그인 세션/토큰 붙이면 교체
-        IssueResponse issue = issueService.createIssue(request, currentUserId);
+    public ResponseEntity<ApiResponse<IssueResponse>> createIssue(
+            @RequestBody CreateIssueRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        UserResponseDTO user = userService.findUserByEmail(userDetails.getUsername());
+        IssueResponse issue = issueService.createIssue(request, user.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(issue));
     }
 
@@ -46,7 +55,8 @@ public class IssueController {
                         filter.page() != null ? filter.page() : 0,
                         filter.size() != null ? filter.size() : 10,
                         filter.sort() != null ? filter.sort() : "createdAt",
-                        filter.order() != null ? filter.order() : "desc"
+                        filter.order() != null ? filter.order() : "desc",
+                        filter.query()
                 ));
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.ok(issue));
     }

--- a/src/main/java/com/issueDive/dto/IssueFilterRequest.java
+++ b/src/main/java/com/issueDive/dto/IssueFilterRequest.java
@@ -13,5 +13,6 @@ public record IssueFilterRequest(
         @Min(0) Integer page,
         @Min(1) Integer size,
         @Pattern(regexp = "createdAt|updatedAt") String sort,
-        @Pattern(regexp = "asc|desc|ASC|DESC") String order
+        @Pattern(regexp = "asc|desc|ASC|DESC") String order,
+        String query
 ) {}

--- a/src/main/java/com/issueDive/security/CustomUserDetailsService.java
+++ b/src/main/java/com/issueDive/security/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package com.issueDive.security;
 
 import com.issueDive.entity.User;
 import com.issueDive.repository.UserRepository;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CustomUserDetailsService implements UserDetailsService{
+
     private final UserRepository userRepository;
 
     @Override

--- a/src/main/java/com/issueDive/service/IssueService.java
+++ b/src/main/java/com/issueDive/service/IssueService.java
@@ -72,6 +72,10 @@ public class IssueService {
         if (filter.assigneeId()!=null) builder.and(qIssue.assignee.id.eq(filter.assigneeId()));
         if (filter.labelIds()!=null && !filter.labelIds().isEmpty()) builder.and(qIssue.labels.any().id.in(filter.labelIds()));
 
+        if (filter.query() != null && !filter.query().isBlank()) {
+            builder.and(qIssue.title.containsIgnoreCase(filter.query()));
+        }
+        
         // 페이징 객체
         int page = filter.page();
         int size = filter.size();

--- a/src/test/java/com/issueDive/controller/AuthControllerTest.java
+++ b/src/test/java/com/issueDive/controller/AuthControllerTest.java
@@ -1,16 +1,17 @@
 package com.issueDive.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.issueDive.dto.LoginRequestDTO;
-import com.issueDive.dto.UserRequestDTO;
 import com.issueDive.dto.UserResponseDTO;
 import com.issueDive.exception.AuthenticationFailedException;
 import com.issueDive.exception.UserNotFoundException;
+import com.issueDive.security.CustomUserDetailsService;
 import com.issueDive.service.UserService;
+import com.issueDive.util.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,79 +26,110 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+/**
+ * @WebMvcTest: 웹 계층(컨트롤러)에 대한 슬라이스 테스트를 진행합니다.
+ * @AutoConfigureMockMvc: MockMvc를 자동으로 설정하며, addFilters = false를 통해
+ * AuthController의 공개 API 테스트 시 Spring Security 필터를 적용하지 않습니다.
+ */
 @WebMvcTest(controllers = AuthController.class)
-@AutoConfigureMockMvc(addFilters = false) // 보안 필터 끄고 컨트롤러만 테스트
+@AutoConfigureMockMvc(addFilters = false)
 public class AuthControllerTest {
-    @Autowired
-    MockMvc mvc;
 
     @Autowired
-    ObjectMapper om;
+    private MockMvc mvc; // HTTP 요청을 시뮬레이션하는 Mock 객체
+
+    @Autowired
+    private ObjectMapper om; // Java 객체와 JSON 간의 변환을 담당
+
+    // --- MockitoBean: 테스트 대상 컨트롤러의 의존성을 가짜(Mock) 객체로 주입 ---
+    @MockitoBean
+    private UserService userService;
+
+    // SecurityConfig를 로드하지 않으므로, AuthController가 의존하는 Bean들을 Mock으로 등록
+    @MockitoBean
+    private AuthenticationManager authenticationManager;
 
     @MockitoBean
-    UserService userService;
+    private JwtUtil jwtUtil;
+
+    // Security Filter Chain이 로드될 때를 대비하여 의존성 Mock Bean 추가
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
 
     @Test
-    @DisplayName("POST /auth/signup → 201 Created")
+    @DisplayName("[SUCCESS] POST /auth/signup - 회원가입 성공")
     void signUp_success() throws Exception {
-        // 요청 바디를 Map으로 만들어 DTO 생성자 유무와 무관하게 바인딩
-        var req = Map.of(
+        // given: 회원가입 요청 데이터와 예상되는 응답 DTO 설정
+        var requestBody = Map.of(
                 "username", "alice",
                 "email", "alice@test.com",
                 "password", "pw123"
         );
-        var res = new UserResponseDTO(1L, "alice", "alice@test.com");
-        given(userService.signUp(any())).willReturn(res);
+        var responseDto = new UserResponseDTO(1L, "alice", "alice@test.com");
 
+        // userService.signUp 메서드가 호출될 때 위에서 정의한 DTO를 반환하도록 설정
+        given(userService.signUp(any())).willReturn(responseDto);
+
+        // when & then: API를 호출하고 응답을 검증
         mvc.perform(post("/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(om.writeValueAsString(req)))
-                .andExpect(status().isCreated())
+                        .content(om.writeValueAsString(requestBody)))
+                .andExpect(status().isCreated()) // 201 Created 상태 코드 확인
+                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.username").value("alice"))
                 .andExpect(jsonPath("$.data.email").value("alice@test.com"));
     }
 
     @Test
-    @DisplayName("POST /auth/login(username/password) → 200 OK")
+    @DisplayName("[SUCCESS] POST /auth/login - 로그인 성공")
     void login_success() throws Exception {
-        // LoginRequestDTO는 username/password로 변경됨
-        var req = Map.of(
-                "username", "alice@test.com",
+        // given: 로그인 요청 데이터 설정
+        var requestBody = Map.of(
+                "email", "alice@test.com",  //  ** LoginRequestDTO의 필드명인 'email'로 수정
                 "password", "pw123"
         );
-        var res = new UserResponseDTO(1L, "alice", "alice@test.com");
-        // 컨트롤러가 userService.login(username, password) 호출한다고 가정
-        given(userService.login(anyString(), anyString())).willReturn(res);
+        var userResponse = new UserResponseDTO(1L, "alice", "alice@test.com");
 
+        // 컨트롤러의 로그인 로직에 필요한 Mocking 설정
+        given(userService.findUserByEmail(anyString())).willReturn(userResponse);
+        given(jwtUtil.generateAccessToken(anyLong(), anyString())).willReturn("mock-access-token");
+
+        // when & then
         mvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(om.writeValueAsString(req)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.email").value("alice@test.com"));
+                        .content(om.writeValueAsString(requestBody)))
+                .andExpect(status().isOk()) // 200 OK 상태 코드 확인
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.user.email").value("alice@test.com"));
     }
 
     @Test
-    @DisplayName("POST /auth/login - 인증 실패 → 401")
+    @DisplayName("[FAIL] POST /auth/login - 로그인 실패 (인증 오류)")
     void login_fail() throws Exception {
-        var req = Map.of(
-                "username", "nope@test.com",
+        // given: 잘못된 로그인 정보
+        var requestBody = Map.of(
+                "email", "nope@test.com",
                 "password", "wrong"
         );
-        given(userService.login(anyString(), anyString()))
-                .willThrow(new AuthenticationFailedException());
 
+        // 인증 실패 시 AuthenticationFailedException이 발생하도록 설정
+        given(authenticationManager.authenticate(any())).willThrow(new AuthenticationFailedException());
+
+        // when & then
         mvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(om.writeValueAsString(req)))
-                .andExpect(status().isUnauthorized());
+                        .content(om.writeValueAsString(requestBody)))
+                .andExpect(status().isUnauthorized()); // 401 Unauthorized 상태 코드 확인
     }
 
     @Test
-    @DisplayName("GET /auth/users/{id} → 200 OK")
+    @DisplayName("[SUCCESS] GET /auth/users/{id} - 특정 사용자 조회 성공")
     void getUserById_success() throws Exception {
+        // given
         given(userService.findUserById(1L))
                 .willReturn(new UserResponseDTO(1L, "alice", "alice@test.com"));
 
+        // when & then
         mvc.perform(get("/auth/users/{id}", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(1L))
@@ -105,35 +137,42 @@ public class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("GET /auth/users/{id} - 없음 → 404")
+    @DisplayName("[FAIL] GET /auth/users/{id} - 존재하지 않는 사용자 조회")
     void getUserById_notFound() throws Exception {
+        // given
         given(userService.findUserById(999L))
                 .willThrow(new UserNotFoundException(999L));
 
+        // when & then
         mvc.perform(get("/auth/users/{id}", 999L))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isNotFound()); // 404 Not Found 상태 코드 확인
     }
 
     @Test
-    @DisplayName("GET /auth/users - 전체 목록 → 200 OK")
+    @DisplayName("[SUCCESS] GET /auth/users - 전체 사용자 목록 조회 성공")
     void getAllUsers_success() throws Exception {
-        var list = List.of(
+        // given
+        var userList = List.of(
                 new UserResponseDTO(1L, "a", "a@test.com"),
                 new UserResponseDTO(2L, "b", "b@test.com")
         );
-        given(userService.getAllUsers()).willReturn(list);
+        given(userService.getAllUsers()).willReturn(userList);
 
+        // when & then
         mvc.perform(get("/auth/users"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].email").value("a@test.com"))
                 .andExpect(jsonPath("$.data[1].username").value("b"));
     }
 
     @Test
-    @DisplayName("DELETE /auth/user/{id} → 200 OK")
+    @DisplayName("[SUCCESS] DELETE /auth/user/{id} - 사용자 삭제 성공")
     void deleteUser_success() throws Exception {
+        // given
         doNothing().when(userService).deleteUser(1L);
 
+        // when & then
         mvc.perform(delete("/auth/user/{id}", 1L))
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/issueDive/controller/CommentControllerTest.java
+++ b/src/test/java/com/issueDive/controller/CommentControllerTest.java
@@ -1,22 +1,29 @@
 package com.issueDive.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.issueDive.dto.CommentResponse;
-import com.issueDive.dto.CountCommentResponse;
-import com.issueDive.dto.CreateCommentRequest;
-import com.issueDive.dto.UpdateCommentRequest;
+import com.issueDive.dto.*;
+import com.issueDive.entity.User;
 import com.issueDive.exception.CommentNotFoundException;
+import com.issueDive.repository.UserRepository;
+import com.issueDive.security.CustomUserDetailsService;
 import com.issueDive.service.CommentService;
+import com.issueDive.service.UserService;
+import com.issueDive.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,9 +34,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.springframework.security.test.context.support.WithMockUser;
-
-@WithMockUser
+/**
+ * @WebMvcTest: CommentController와 관련된 웹 계층 빈들만 로드합니다.
+ * @AutoConfigureMockMvc: MockMvc를 자동으로 설정하며, Spring Security 필터를 활성화합니다.
+ * @WithMockUser: 이 클래스의 모든 테스트에 'test@example.com' 사용자로 로그인한 상태를 전역 적용합니다.
+ */
+@WithMockUser(username = "test@example.com", roles = "USER")
+@AutoConfigureMockMvc
 @WebMvcTest(CommentController.class)
 class CommentControllerTest {
 
@@ -39,20 +50,53 @@ class CommentControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    // --- MockitoBean: 테스트 대상 컨트롤러의 의존성을 가짜(Mock) 객체로 주입 ---
     @MockitoBean
     private CommentService commentService;
 
+    // 컨트롤러가 의존하는 UserRepository Mock Bean 추가
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private UserService userService;
+
+    // Security Filter Chain 구성을 위해 필요한 의존성 Mock Bean 추가
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    // 테스트에서 공통으로 사용할 ID 값들
     private final Long issueId = 1L;
-    private final Long userId = 1L;
     private final Long commentId = 1L;
+    private final Long currentUserId = 1L; // @WithMockUser와 @BeforeEach에서 설정된 사용자의 ID
+
+    /**
+     * @BeforeEach: 각 테스트 메서드 실행 전에 공통적으로 필요한 설정을 수행합니다.
+     */
+    @BeforeEach
+    void setUp() {
+        // given: Mock 유저 정보 설정
+        User mockUser = new User();
+        mockUser.setId(currentUserId);
+        mockUser.setEmail("test@example.com");
+        var userResponseDto = new UserResponseDTO(currentUserId, "testuser", "test@example.com");
+
+        Mockito.when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(mockUser));
+        // 컨트롤러가 호출할 userService.findUserByEmail의 동작을 설정
+        Mockito.when(userService.findUserByEmail("test@example.com")).thenReturn(userResponseDto);
+    }
+
 
     @Test
-    @DisplayName("이슈의 모든 댓글 조회 - 성공")
+    @DisplayName("[SUCCESS] GET /issues/{issueId}/comments - 이슈의 모든 댓글 조회")
     void getComments_Success() throws Exception {
-        // given
+        // given: 서비스가 빈 댓글 리스트를 반환하도록 설정
         when(commentService.getTreeByIssue(issueId)).thenReturn(Collections.emptyList());
 
-        // when & then
+        // when & then: API 호출 및 응답 검증
         mockMvc.perform(get("/issues/{issueId}/comments", issueId))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -60,25 +104,19 @@ class CommentControllerTest {
     }
 
     @Test
-    @DisplayName("댓글 생성 - 성공")
+    @DisplayName("[SUCCESS] POST /issues/{issueId}/comments - 댓글 생성")
     void createComment_Success() throws Exception {
-        // given
+        // given: 요청 DTO 및 Mock 응답 DTO 생성
         CreateCommentRequest request = new CreateCommentRequest();
         request.setDescription("New Comment");
 
-        CommentResponse response = CommentResponse.builder()
-                .id(commentId)
-                .description("New Comment")
-                .author("testuser")
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        when(commentService.createComment(eq(issueId), any(CreateCommentRequest.class), eq(userId))).thenReturn(response);
+        CommentResponse response = CommentResponse.builder().id(commentId).description("New Comment").author("testuser").createdAt(LocalDateTime.now()).build();
+        // 서비스 메서드가 올바른 사용자 ID(currentUserId)로 호출될 때, 위에서 만든 응답을 반환하도록 설정
+        when(commentService.createComment(eq(issueId), any(CreateCommentRequest.class), eq(currentUserId))).thenReturn(response);
 
         // when & then
         mockMvc.perform(post("/issues/{issueId}/comments", issueId)
-                        .with(csrf())
-                        .header("X-USER-ID", userId)
+                        .with(csrf()) // POST, PATCH, DELETE 등 CSRF 보호가 필요한 요청에 추가
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
@@ -88,23 +126,18 @@ class CommentControllerTest {
     }
 
     @Test
-    @DisplayName("댓글 수정 - 성공")
+    @DisplayName("[SUCCESS] PATCH /issues/{issueId}/comments/{commentId} - 댓글 수정")
     void updateComment_Success() throws Exception {
         // given
         UpdateCommentRequest request = new UpdateCommentRequest();
         request.setDescription("Updated Comment");
 
-        CommentResponse response = CommentResponse.builder()
-                .id(commentId)
-                .description("Updated Comment")
-                .build();
-
-        when(commentService.updateComment(eq(issueId), eq(commentId), any(UpdateCommentRequest.class), eq(userId))).thenReturn(response);
+        CommentResponse response = CommentResponse.builder().id(commentId).description("Updated Comment").build();
+        when(commentService.updateComment(eq(issueId), eq(commentId), any(UpdateCommentRequest.class), eq(currentUserId))).thenReturn(response);
 
         // when & then
         mockMvc.perform(patch("/issues/{issueId}/comments/{commentId}", issueId, commentId)
                         .with(csrf())
-                        .header("X-USER-ID", userId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
@@ -114,78 +147,74 @@ class CommentControllerTest {
     }
 
     @Test
-    @DisplayName("댓글 삭제 - 성공")
+    @DisplayName("[SUCCESS] DELETE /issues/{issueId}/comments/{commentId} - 댓글 삭제")
     void deleteComment_Success() throws Exception {
-        // given
+        // given: commentService.deleteComment가 currentUserId로 호출될 때 아무것도 하지 않도록 설정
+        doNothing().when(commentService).deleteComment(issueId, commentId, currentUserId);
+
         // when & then
         mockMvc.perform(delete("/issues/{issueId}/comments/{commentId}", issueId, commentId)
-                        .with(csrf())
-                        .header("X-USER-ID", userId))
+                        .with(csrf()))
                 .andDo(print())
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNoContent()); // 204 No Content 상태 코드 확인
 
-        verify(commentService).deleteComment(issueId, commentId, userId);
+        // 서비스의 deleteComment가 정확한 인자들로 호출되었는지 검증
+        verify(commentService).deleteComment(issueId, commentId, currentUserId);
     }
 
     @Test
-    @DisplayName("댓글 생성 - 내용 없음 - 400 Bad Request")
+    @DisplayName("[FAIL] POST /issues/{issueId}/comments - 내용 없이 댓글 생성")
     void createComment_BlankDescription_ReturnsBadRequest() throws Exception {
-        // given
+        // given: 유효성 검증(@NotBlank)에 실패할 요청 생성
         CreateCommentRequest request = new CreateCommentRequest();
-        request.setDescription(""); // 유효성 검증에 실패할 내용
+        request.setDescription("");
 
         // when & then
         mockMvc.perform(post("/issues/{issueId}/comments", issueId)
                         .with(csrf())
-                        .header("X-USER-ID", userId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest()); // 400 Bad Request 상태 코드 확인
     }
 
     @Test
-    @DisplayName("댓글 수정 - 댓글 없음 - 404 Not Found")
+    @DisplayName("[FAIL] PATCH /issues/{issueId}/comments/{commentId} - 존재하지 않는 댓글 수정")
     void updateComment_CommentNotFound_ReturnsNotFound() throws Exception {
         // given
         UpdateCommentRequest request = new UpdateCommentRequest();
         request.setDescription("Updated Comment");
-
-        when(commentService.updateComment(eq(issueId), eq(commentId), any(UpdateCommentRequest.class), eq(userId)))
+        // 서비스가 CommentNotFoundException을 던지도록 설정
+        when(commentService.updateComment(eq(issueId), eq(commentId), any(UpdateCommentRequest.class), eq(currentUserId)))
                 .thenThrow(new CommentNotFoundException("댓글을 찾을 수 없습니다."));
 
         // when & then
         mockMvc.perform(patch("/issues/{issueId}/comments/{commentId}", issueId, commentId)
                         .with(csrf())
-                        .header("X-USER-ID", userId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(status().isNotFound()) // 404 Not Found 상태 코드 확인
                 .andExpect(jsonPath("$.error.code").value("CommentNotFound"));
     }
 
-    // @Test // JWT 인증 활성 전까지 임시 테스트 제외
-    @DisplayName("댓글 삭제 - 권한 없음 - 403 Forbidden")
+    @Test
+    @DisplayName("[FAIL] DELETE /issues/{issueId}/comments/{commentId} - 권한 없는 댓글 삭제")
     void deleteComment_NotOwner_ReturnsForbidden() throws Exception {
-        // given
-        Long notOwnerId = 999L;
+        // given: 서비스가 SecurityException을 던지도록 설정 (권한 없음을 시뮬레이션)
         doThrow(new SecurityException("댓글 작성자가 아닙니다."))
-                .when(commentService).deleteComment(issueId, commentId, notOwnerId);
+                .when(commentService).deleteComment(issueId, commentId, currentUserId);
 
         // when & then
         mockMvc.perform(delete("/issues/{issueId}/comments/{commentId}", issueId, commentId)
-                        .with(csrf())
-                        .header("X-USER-ID", notOwnerId))
+                        .with(csrf()))
                 .andDo(print())
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(status().isForbidden()) // 403 Forbidden 상태 코드 확인
                 .andExpect(jsonPath("$.error.code").value("Forbidden"));
     }
 
     @Test
-    @DisplayName("댓글 개수 조회 - 성공")
+    @DisplayName("[SUCCESS] GET /issues/{issueId}/comments/count - 댓글 개수 조회")
     void countComment_Success() throws Exception {
         // given
         long count = 10L;
@@ -195,7 +224,6 @@ class CommentControllerTest {
         mockMvc.perform(get("/issues/{issueId}/comments/count", issueId))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.issueId").value(issueId))
                 .andExpect(jsonPath("$.data.count").value(count));
     }

--- a/src/test/java/com/issueDive/controller/IssueControllerTest.java
+++ b/src/test/java/com/issueDive/controller/IssueControllerTest.java
@@ -1,12 +1,21 @@
 package com.issueDive.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issueDive.dto.CreateIssueRequest;
 import com.issueDive.dto.IssueFilterRequest;
 import com.issueDive.dto.IssueResponse;
+import com.issueDive.dto.UserResponseDTO;
+import com.issueDive.entity.User;
 import com.issueDive.exception.ErrorCode;
 import com.issueDive.exception.NotFoundException;
 import com.issueDive.exception.ValidationException;
+import com.issueDive.repository.UserRepository;
+import com.issueDive.security.CustomUserDetailsService;
 import com.issueDive.service.IssueService;
+import com.issueDive.service.UserService;
+import com.issueDive.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,122 +25,159 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
-// import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@AutoConfigureMockMvc(addFilters = false) // 필터(보안) 비활성화
-@WebMvcTest(IssueController.class) // IssueController만 로딩
+/**
+ * @WebMvcTest: IssueController와 관련된 웹 계층 빈들만 로드합니다.
+ * @AutoConfigureMockMvc: MockMvc를 자동으로 설정합니다. (addFilters = false 제거로 Security 필터 활성화)
+ * @WithMockUser: 이 클래스의 모든 테스트에 'test@example.com' 사용자로 로그인한 상태를 전역 적용합니다.
+ */
+@WithMockUser(username = "test@example.com", roles = "USER")
+@AutoConfigureMockMvc
+@WebMvcTest(IssueController.class)
 public class IssueControllerTest {
 
     @Autowired
-    private MockMvc mockMvc; // 가상의 HTTP 요청, 응답을 시뮬레이트하는 객체
+    private MockMvc mockMvc; // HTTP 요청 시뮬레이션 객체
+
+    @Autowired
+    private ObjectMapper objectMapper; // JSON <-> Java Object 변환 객체
+
+    // --- MockitoBean: 테스트 대상 컨트롤러의 의존성을 가짜(Mock) 객체로 주입 ---
+    @MockitoBean
+    private IssueService issueService;
+
+    // 컨트롤러의 의존성인 UserRepository를 Mock Bean으로 추가
+    @MockitoBean
+    private UserRepository userRepository;
+    @MockitoBean
+    private UserService userService;
+
+    // Security Filter Chain 구성을 위해 필요한 의존성 Mock Bean 추가
+    @MockitoBean
+    private JwtUtil jwtUtil;
 
     @MockitoBean
-    private IssueService issueService; // 서비스 레이어는 Mock으로 대체해 컨트롤러만 테스트
+    private CustomUserDetailsService customUserDetailsService;
+
+    // 테스트 전역에서 사용할 Mock 유저의 ID
+    private final Long currentUserId = 1L;
+
+    /**
+     * @BeforeEach: 각 테스트 메서드 실행 전에 공통적으로 필요한 설정을 수행합니다.
+     */
+    @BeforeEach
+    void setUp() {
+        // given: Mock 유저 정보 설정
+        User mockUser = new User();
+        mockUser.setId(currentUserId);
+        mockUser.setEmail("test@example.com");
+        var userResponseDto = new UserResponseDTO(currentUserId, "testuser", "test@example.com");
+
+        // 컨트롤러에서 @AuthenticationPrincipal을 통해 얻은 이메일로 DB 조회를 시도할 것이므로,
+        // userRepository.findByEmail이 호출될 때 위에서 만든 Mock 유저 객체를 반환하도록 설정합니다.
+        Mockito.when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(mockUser));
+
+        // 컨트롤러가 호출할 userService.findUserByEmail의 동작을 설정
+        Mockito.when(userService.findUserByEmail("test@example.com")).thenReturn(userResponseDto);
+    }
+
 
     @Test
+    @DisplayName("[SUCCESS] POST /issues - 이슈 생성 성공")
     public void createIssue_success() throws Exception {
+        // given: 서비스가 반환할 Mock 응답 데이터 생성
+        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", currentUserId, 2L, List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
 
-        // given
-        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", 1L, 2L,
-                List.of(1L, 2L),  // 라벨 ID 리스트 샘플, 테스트에 맞춰 변경 가능
-                LocalDateTime.now(),  // createdAt 예시
-                LocalDateTime.now()   // updatedAt 예시
-        );
-
-        Mockito.when(issueService.createIssue(any(CreateIssueRequest.class), anyLong())).thenReturn(mockResponse);
+        // issueService의 createIssue 메서드가 'currentUserId'와 함께 호출될 때, mockResponse를 반환하도록 설정
+        Mockito.when(issueService.createIssue(any(CreateIssueRequest.class), eq(currentUserId))).thenReturn(mockResponse);
 
         String requestBody = """
             {
                 "title": "제목",
                 "description": "설명",
-                "assignee_id": 2
+                "assigneeId": 2
             }
             """;
 
-        // when: HTTP POST 요청 시뮬레이션
+        // when & then: API를 호출하고 응답을 검증
         mockMvc.perform(post("/issues")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody)) // 요청 본문에 JSON 설정
-                // then: 응답 확인
+                        .content(requestBody))
                 .andExpect(status().isCreated()) // 201 Created
-                .andExpect(jsonPath("$.success").value(true)) // 응답 JSON 성공 여부 확인
-                .andExpect(jsonPath("$.data.id").value(1)) // 데이터 내 id 값 검증
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.title").value("제목"))
-                .andExpect(jsonPath("$.data.status").value("OPEN"));
+                .andExpect(jsonPath("$.data.authorId").value(currentUserId));
     }
 
-    /**
-     * 다중 조회
-     */
     @Test
+    @DisplayName("[SUCCESS] GET /issues - 이슈 목록 필터링 및 페이징 조회 성공")
     void getIssues_returnsPagedResults() throws Exception {
-        // given: Mock Service가 반환할 Page 객체를 미리 생성
+        // given: Mock Service가 반환할 Page 객체 생성
         List<IssueResponse> issueList = List.of(
-                new IssueResponse(1L, "첫 번째 이슈", "설명 1", "OPEN", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now()),
-                new IssueResponse(2L, "두 번째 이슈", "설명 2", "OPEN", 1L, 3L, List.of(), LocalDateTime.now(), LocalDateTime.now())
+                new IssueResponse(1L, "첫 번째 이슈", "설명 1", "OPEN", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now())
         );
         Page<IssueResponse> mockPage = new PageImpl<>(issueList, PageRequest.of(0, 10), issueList.size());
 
-        // issueService.getFilteredIssues()가 어떤 IssueFilterRequest 객체로 호출되든, 위에서 만든 mockPage 객체를 반환하도록 설정
         Mockito.when(issueService.getFilteredIssues(any(IssueFilterRequest.class)))
                 .thenReturn(mockPage);
 
-        // when-then: API를 호출하고 응답을 검증
+        // when & then
         mockMvc.perform(get("/issues")
                         .param("status", "OPEN")
-                        .param("page", "0")
-                        .param("size", "10"))
+                        .param("page", "0"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content").isArray())
                 .andExpect(jsonPath("$.data.content[0].id").value(1))
-                .andExpect(jsonPath("$.data.pageable.pageNumber").value(0));
+                .andExpect(jsonPath("$.data.totalElements").value(1));
     }
 
-    /**
-     * 단건 조회
-     */
     @Test
+    @DisplayName("[SUCCESS] GET /issues/{id} - 특정 이슈 조회 성공")
     public void getIssue_success() throws Exception {
         // given
-        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", 1L, 2L,
-                List.of(1L, 2L),  // 라벨 ID 리스트 샘플, 테스트에 맞춰 변경 가능
-                LocalDateTime.now(),  // createdAt 예시
-                LocalDateTime.now()   // updatedAt 예시
-        );
-        Mockito.when(issueService.getIssue(1L)).thenReturn(mockResponse); // issueService.getIssue(1L) 호출 시 mockResponse 반환하도록 Stub 설정
+        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now());
+        Mockito.when(issueService.getIssue(1L)).thenReturn(mockResponse);
 
-        // when: HTTP GET 요청 시뮬레이션
+        // when & then
         mockMvc.perform(get("/issues/1"))
-                // then: 응답 확인
-                .andExpect(status().isOk()) // HTTP 200 OK
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.title").value("제목"));
     }
 
-    /**
-     * 이슈 상태 변경 API 테스트
-     * 성공
-     */
     @Test
-    void changeIssueStatus_success() throws Exception {
-
+    @DisplayName("[FAIL] GET /issues/{id} - 존재하지 않는 이슈 조회")
+    void getIssue_notFound_fail() throws Exception {
         // given
-        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "CLOSED", 1L, 2L,
-                List.of(1L, 2L),  // 라벨 ID 리스트 샘플, 테스트에 맞춰 변경 가능
-                LocalDateTime.now(),  // createdAt 예시
-                LocalDateTime.now()   // updatedAt 예시
-        );
+        Mockito.when(issueService.getIssue(999L)).thenThrow(new NotFoundException("Issue not found"));
+
+        // when & then
+        mockMvc.perform(get("/issues/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("IssueNotFound"));
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] PATCH /issues/{id}/status - 이슈 상태 변경 성공")
+    void changeIssueStatus_success() throws Exception {
+        // given
+        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "CLOSED", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now());
         Mockito.when(issueService.changeIssueStatus(1L, "CLOSED")).thenReturn(mockResponse);
 
         String requestBody = """
@@ -140,25 +186,21 @@ public class IssueControllerTest {
         }
         """;
 
-        // when: HTTP PATCH 요청
+        // when & then
         mockMvc.perform(patch("/issues/1/status")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                // then: 성공 응답 확인
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("CLOSED"));
     }
 
-    /**
-     * 이슈 상태 변경 API 테스트
-     * 실패: Invalid Status
-     */
     @Test
+    @DisplayName("[FAIL] PATCH /issues/{id}/status - 유효하지 않은 상태 값으로 변경")
     void changeIssueStatus_invalidStatus_badRequest() throws Exception {
-
         // given
-        Mockito.when(issueService.changeIssueStatus(Mockito.eq(1L), Mockito.eq("INVALID")))
+        Mockito.when(issueService.changeIssueStatus(1L, "INVALID"))
                 .thenThrow(new ValidationException(ErrorCode.InvalidStatus, "status must be either OPEN or CLOSED"));
 
         String requestBody = """
@@ -167,42 +209,12 @@ public class IssueControllerTest {
         }
         """;
 
-        // when: HTTP PATCH 요청
+        // when & then
         mockMvc.perform(patch("/issues/1/status")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                // then: BadRequest (400) Invalid Status 에러 응답 확인
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("InvalidStatus"));
     }
-
-    /**
-     * 이슈 상태 변경 API 테스트
-     * 실패: Issue Not Found
-     */
-    @Test
-    void changeIssueStatus_issueNotFound_notFound() throws Exception {
-
-        // given
-        Mockito.when(issueService.changeIssueStatus(Mockito.eq(99L), Mockito.anyString()))
-                .thenThrow(new NotFoundException("Issue not found"));
-
-        String requestBody = """
-        {
-            "status": "CLOSED"
-        }
-        """;
-
-        // when: HTTP PATCH 요청
-        mockMvc.perform(patch("/issues/99/status")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                // then: NotFound (404) 에러 응답 확인
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("IssueNotFound"));
-    }
-
-
 }

--- a/src/test/java/com/issueDive/controller/LabelControllerTest.java
+++ b/src/test/java/com/issueDive/controller/LabelControllerTest.java
@@ -1,64 +1,71 @@
 package com.issueDive.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issueDive.dto.CreateLabelRequest;
 import com.issueDive.dto.IssueLabelsResponse;
 import com.issueDive.dto.LabelResponse;
 import com.issueDive.exception.*;
+import com.issueDive.security.CustomUserDetailsService;
 import com.issueDive.service.IssueLabelService;
-import com.issueDive.service.IssueService;
 import com.issueDive.service.LabelService;
+import com.issueDive.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@AutoConfigureMockMvc(addFilters = false)
+
+/**
+ * @WebMvcTest: LabelController와 관련된 웹 계층 빈들만 로드합니다.
+ * @AutoConfigureMockMvc: MockMvc를 자동으로 설정하며, Spring Security 필터를 활성화합니다.
+ * @WithMockUser: 이 클래스의 모든 테스트에 로그인한 상태를 전역 적용합니다.
+ */
+@WithMockUser
+@AutoConfigureMockMvc
 @WebMvcTest(LabelController.class)
 class LabelControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper; // ObjectMapper 주입
+
+    // --- MockitoBean: 테스트 대상 컨트롤러의 의존성을 가짜(Mock) 객체로 주입 ---
     @MockitoBean
-    private LabelService labelService; // 서비스는 Mock으로 대체
+    private LabelService labelService;
 
     @MockitoBean
     private IssueLabelService issueLabelService;
 
+    // Security Filter Chain 구성을 위해 필요한 의존성 Mock Bean 추가
     @MockitoBean
-    private IssueService issueService;
+    private JwtUtil jwtUtil;
 
-    /**
-     * 라벨 생성 테스트
-     * 성공
-     */
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
     @Test
+    @DisplayName("[SUCCESS] POST /labels - 라벨 생성 성공")
     void createLabel_success() throws Exception {
-        // given
-        LabelResponse mock = LabelResponse.builder()
-                .id(10L)
-                .name("bug")
-                .color("#FF0000")
-                .description("버그 관련 이슈")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
+        // given: 서비스가 반환할 Mock 응답 데이터 생성
+        LabelResponse mockResponse = LabelResponse.builder().id(10L).name("bug").color("#FF0000").build();
+        Mockito.when(labelService.createLabel(any(CreateLabelRequest.class))).thenReturn(mockResponse);
 
-        Mockito.when(labelService.createLabel(any(CreateLabelRequest.class)))
-                .thenReturn(mock);
-
-        String body = """
+        String requestBody = """
         {
           "name": "bug",
           "color": "#FF0000",
@@ -66,73 +73,45 @@ class LabelControllerTest {
         }
         """;
 
-        // when & then
+        // when & then: API 호출 및 응답 검증
         mockMvc.perform(post("/labels")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isCreated())              // 201
-                .andExpect(jsonPath("$.success").value(true)) // ApiResponse.success
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(10))
-                .andExpect(jsonPath("$.data.name").value("bug"))
-                .andExpect(jsonPath("$.data.color").value("#FF0000"));
+                .andExpect(jsonPath("$.data.name").value("bug"));
     }
 
-    /**
-     * 라벨 생성 테스트
-     * 실패: name 중복 시
-     */
     @Test
+    @DisplayName("[FAIL] POST /labels - 라벨 이름 중복으로 생성 실패")
     void createLabel_duplicateName_BadRequest() throws Exception {
         // given
-        String body = """
-                {
-                  "name": "bug",
-                  "color": "#FF0000",
-                  "description": "버그 관련 이슈"
-                }
-                """;
-
-        // 서비스가 중복 예외를 던지도록 스텁
+        String requestBody = """
+        { "name": "bug", "color": "#FF0000" }
+        """;
+        // 서비스가 중복 예외를 던지도록 설정
         Mockito.when(labelService.createLabel(any(CreateLabelRequest.class)))
                 .thenThrow(new ValidationException(ErrorCode.DuplicateLabel, "이미 존재하는 라벨 이름입니다."));
 
         // when & then
         mockMvc.perform(post("/labels")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                        .content(requestBody))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("DuplicateLabel"))
-                .andExpect(jsonPath("$.error.message").value("이미 존재하는 라벨 이름입니다."));
+                .andExpect(jsonPath("$.error.code").value("DuplicateLabel"));
     }
 
-    /**
-     * 라벨 목록 조회
-     * 성공
-     */
     @Test
+    @DisplayName("[SUCCESS] GET /labels - 전체 라벨 목록 조회 성공")
     void getLabels_success() throws Exception {
         // given
-        LabelResponse label1 = LabelResponse.builder()
-                .id(1L)
-                .name("bug")
-                .color("#FF0000")
-                .description("버그 관련")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-
-        LabelResponse label2 = LabelResponse.builder()
-                .id(2L)
-                .name("feature")
-                .color("#00FF00")
-                .description("기능 추가")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-
-        List<LabelResponse> mockList = List.of(label1, label2);
-
+        List<LabelResponse> mockList = List.of(
+                LabelResponse.builder().id(1L).name("bug").build(),
+                LabelResponse.builder().id(2L).name("feature").build()
+        );
         Mockito.when(labelService.getLabels()).thenReturn(mockList);
 
         // when & then
@@ -140,337 +119,109 @@ class LabelControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].name").value("bug"))
-                .andExpect(jsonPath("$.data[1].id").value(2))
                 .andExpect(jsonPath("$.data[1].name").value("feature"));
     }
 
-    /**
-     * 라벨 목록 조회
-     * 성공 - 데이터 없을 시
-     */
     @Test
-    void getLabels_emptyList() throws Exception {
-        // given
-        Mockito.when(labelService.getLabels()).thenReturn(List.of());
-
-        // when & then
-        mockMvc.perform(get("/labels"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
-
-    /**
-     * 라벨 단일 조회
-     * 성공
-     */
-    @Test
+    @DisplayName("[SUCCESS] GET /labels/{labelId} - 특정 라벨 조회 성공")
     void getLabel_success() throws Exception {
         // given
-        LabelResponse mock = LabelResponse.builder()
-                .id(10L)
-                .name("bug")
-                .color("#FF0000")
-                .description("버그 관련 이슈")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-
-        Mockito.when(labelService.getLabel(10L)).thenReturn(mock);
+        LabelResponse mockResponse = LabelResponse.builder().id(10L).name("bug").color("#FF0000").build();
+        Mockito.when(labelService.getLabel(10L)).thenReturn(mockResponse);
 
         // when & then
         mockMvc.perform(get("/labels/10"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(10))
-                .andExpect(jsonPath("$.data.name").value("bug"))
-                .andExpect(jsonPath("$.data.color").value("#FF0000"));
+                .andExpect(jsonPath("$.data.name").value("bug"));
     }
 
-
-    /**
-     * 라벨 단일 조회
-     * 실패: 존재하지 않는 라벨 조회 시
-     */
     @Test
+    @DisplayName("[FAIL] GET /labels/{labelId} - 존재하지 않는 라벨 조회")
     void getLabel_labelNotFound_notFound() throws Exception {
         // given
-        Mockito.when(labelService.getLabel(99L))
-                .thenThrow(new LabelNotFoundException("라벨을 찾을 수 없습니다."));
+        Mockito.when(labelService.getLabel(99L)).thenThrow(new LabelNotFoundException("라벨을 찾을 수 없습니다."));
 
         // when & then
         mockMvc.perform(get("/labels/99"))
-                .andExpect(status().isNotFound())                 // 404
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("LabelNotFound"))
-                .andExpect(jsonPath("$.error.message").exists());
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("LabelNotFound"));
     }
 
-    /**
-     * 라벨 수정
-     * 성공
-     */
     @Test
-    void updateLabel_duplicateName_returnsBadRequest() throws Exception {
+    @DisplayName("[SUCCESS] PATCH /labels/{labelId} - 라벨 수정 성공")
+    void updateLabel_success() throws Exception {
         // given
         Long labelId = 10L;
-        String body = """
-        {
-          "name": "bug",
-          "color": "#000000",
-          "description": "중복 이름"
-        }
-        """;
-
-        Mockito.when(labelService.updateLabel(eq(labelId), any()))
-                .thenThrow(new ValidationException(ErrorCode.DuplicateLabel, "이미 존재하는 라벨 이름입니다."));
+        String requestBody = """
+            { "name": "critical bug", "color": "#000000" }
+            """;
+        LabelResponse mockResponse = LabelResponse.builder().id(labelId).name("critical bug").color("#000000").build();
+        Mockito.when(labelService.updateLabel(eq(labelId), any())).thenReturn(mockResponse);
 
         // when & then
         mockMvc.perform(patch("/labels/{labelId}", labelId)
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isBadRequest())                    // 400
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("DuplicateLabel"))
-                .andExpect(jsonPath("$.error.message").value("이미 존재하는 라벨 이름입니다."));
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("critical bug"))
+                .andExpect(jsonPath("$.data.color").value("#000000"));
     }
 
-    /**
-     * 라벨 수정
-     * 실패: name 중복 시
-     */
     @Test
-    void updateLabel_duplicateName() throws Exception {
-        // given
-        Long labelId = 10L;
-        String body = """
-        {
-          "name": "bug",
-          "color": "#000000",
-          "description": "중복 이름"
-        }
-        """;
-
-        Mockito.when(labelService.updateLabel(eq(labelId), any()))
-                .thenThrow(new ValidationException(ErrorCode.DuplicateLabel, "이미 존재하는 라벨 이름입니다."));
-
-        // when & then
-        mockMvc.perform(patch("/labels/{id}", labelId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isBadRequest())                    // 400
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("DuplicateLabel"))      // <-- 여기
-                .andExpect(jsonPath("$.error.message").value("이미 존재하는 라벨 이름입니다."));  // <-- 여기
-    }
-
-    /**
-     * 라벨 수정
-     * 실패: 존재하지 않는 라벨 수정 시
-     */
-    @Test
-    void updateLabel_notFound() throws Exception {
-        // given
-        Long labelId = 999L;
-        String body = """
-        {
-          "name": "nonexistent",
-        "color": "#123456",
-        "description": "없는 라벨"
-        }
-        """;
-
-        Mockito.when(labelService.updateLabel(eq(labelId), any()))
-                .thenThrow(new LabelNotFoundException("라벨을 찾을 수 없습니다."));
-
-        // when & then
-        mockMvc.perform(patch("/labels/{id}", labelId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isNotFound())               // 404
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("LabelNotFound"))
-                .andExpect(jsonPath("$.error.message").value("라벨을 찾을 수 없습니다."));
-    }
-
-    /**
-     * 라벨 삭제
-     * 성공
-     */
-    @Test
+    @DisplayName("[SUCCESS] DELETE /labels/{labelId} - 라벨 삭제 성공")
     void deleteLabel_success() throws Exception {
         // given
         Long labelId = 10L;
-
         Mockito.doNothing().when(labelService).deleteLabel(labelId);
 
         // when & then
-        mockMvc.perform(delete("/labels/{id}", labelId))
+        mockMvc.perform(delete("/labels/{id}", labelId)
+                        .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.message").value("Label 10 deleted successfully"));
     }
 
-    /**
-     * 라벨 삭제
-     * 실패: 존재하지 않는 라벨 삭제 시
-     */
     @Test
-    void deleteLabel_labelNotFound_notFound() throws Exception {
-        // given
-        Long labelId = 999L;
-        Mockito.doThrow(new LabelNotFoundException("라벨을 찾을 수 없습니다."))
-                .when(labelService).deleteLabel(labelId);
-
-        // when & then
-        mockMvc.perform(delete("/labels/{id}", labelId))
-                .andExpect(status().isNotFound())                 // 404
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("LabelNotFound"))
-                .andExpect(jsonPath("$.error.message").value("라벨을 찾을 수 없습니다."));
-    }
-
-    /**
-     * 이슈에 라벨 추가
-     * 성공
-     */
-    @Test
+    @DisplayName("[SUCCESS] POST /issues/{issueId}/labels - 이슈에 라벨 추가 성공")
     void addLabelsToIssue_success() throws Exception {
         // given
         Long issueId = 1L;
         List<Long> labelIds = List.of(10L, 20L);
+        IssueLabelsResponse mockResponse = IssueLabelsResponse.builder().id(issueId).build();
+        Mockito.when(issueLabelService.addLabelsToIssue(issueId, labelIds)).thenReturn(mockResponse);
 
-        IssueLabelsResponse mock = IssueLabelsResponse.builder()
-                .id(issueId)
-                .labels(List.of(
-                        IssueLabelsResponse.LabelSummary.builder().id(10L).name("bug").build(),
-                        IssueLabelsResponse.LabelSummary.builder().id(20L).name("feature").build()
-                ))
-                .build();
-
-        Mockito.when(issueLabelService.addLabelsToIssue(issueId, labelIds))
-                .thenReturn(mock);
-
-        String body = "[10, 20]";
+        String requestBody = "[10, 20]";
 
         // when & then
         mockMvc.perform(post("/issues/{issueId}/labels", issueId)
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isOk())                       // 200
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.id").value(1))
-                .andExpect(jsonPath("$.data.labels").isArray())
-                .andExpect(jsonPath("$.data.labels[0].id").value(10))
-                .andExpect(jsonPath("$.data.labels[0].name").value("bug"))
-                .andExpect(jsonPath("$.data.labels[1].id").value(20))
-                .andExpect(jsonPath("$.data.labels[1].name").value("feature"));
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(issueId));
 
+        // issueLabelService의 메서드가 정확한 인자들로 호출되었는지 검증
         Mockito.verify(issueLabelService).addLabelsToIssue(issueId, labelIds);
     }
 
-    /**
-     * 이슈에 라벨 추가
-     * 실패: 이슈 조회 실패 시
-     */
     @Test
-    void addLabelsToIssue_issueNotFound_notfound() throws Exception {
-        // given
-        Long issueId = 999L;
-        String body = "[10, 20]";
-
-        Mockito.when(issueLabelService.addLabelsToIssue(eq(issueId), anyList()))
-                .thenThrow(new NotFoundException("Issue not found"));
-
-        // when & then
-        mockMvc.perform(post("/issues/{issueId}/labels", issueId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isNotFound())                 // 404
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("IssueNotFound"))
-                .andExpect(jsonPath("$.error.message").value("Issue not found"));
-    }
-
-    /**
-     * 이슈에 라벨 추가
-     * 실패: 없는 라벨 추가 시
-     */
-    @Test
-    void addLabelsToIssue_labelNotFound_notFound() throws Exception {
-        // given
-        Long issueId = 1L;
-        String body = "[10, 999]"; // 999가 없는 라벨이라고 가정
-
-        Mockito.when(issueLabelService.addLabelsToIssue(eq(issueId), anyList()))
-                .thenThrow(new LabelNotFoundException("라벨을 찾을 수 없습니다."));
-
-        // when & then
-        mockMvc.perform(post("/issues/{issueId}/labels", issueId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isNotFound())                  // 404
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("LabelNotFound"))
-                .andExpect(jsonPath("$.error.message").value("라벨을 찾을 수 없습니다."));
-    }
-
-    /**
-     * 이슈에서 라벨 제거
-     * 성공
-     */
-    @Test
+    @DisplayName("[SUCCESS] DELETE /issues/{issueId}/labels/{labelId} - 이슈에서 라벨 제거 성공")
     void deleteLabelFromIssue_success() throws Exception {
         // given
         Long issueId = 1L;
         Long labelId = 20L;
-
-        LabelResponse removed = LabelResponse.builder()
-                .id(labelId)
-                .name("feature")
-                .color("#00FF00")
-                .description("기능 추가")
-                .createdAt(LocalDateTime.now().minusDays(2))
-                .updatedAt(LocalDateTime.now())
-                .build();
-
-        Mockito.when(issueLabelService.deleteLabelFromIssue(eq(issueId), eq(labelId)))
-                .thenReturn(removed);
+        LabelResponse mockResponse = LabelResponse.builder().id(labelId).name("feature").build();
+        Mockito.when(issueLabelService.deleteLabelFromIssue(issueId, labelId)).thenReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(delete("/issues/{issueId}/labels/{labelId}", issueId, labelId))
+        mockMvc.perform(delete("/issues/{issueId}/labels/{labelId}", issueId, labelId)
+                        .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.id").value(20))
-                .andExpect(jsonPath("$.data.name").value("feature"));
+                .andExpect(jsonPath("$.data.id").value(labelId));
 
         Mockito.verify(issueLabelService).deleteLabelFromIssue(issueId, labelId);
     }
-
-    /**
-     * 이슈에서 라벨 제거
-     * 실패: 이슈-라벨 매핑 없을 시
-     */
-    @Test
-    void deleteLabelFromIssue_issueLabelNotFound_notFound() throws Exception {
-        // given
-        Long issueId = 1L;
-        Long labelId = 999L; // 이 이슈에 매핑되지 않은 라벨이라고 가정
-
-        Mockito.when(issueLabelService.deleteLabelFromIssue(eq(issueId), eq(labelId)))
-                .thenThrow(new IssueLabelNotFoundException("이 이슈에 해당 라벨 매핑이 없습니다."));
-
-        // when & then
-        mockMvc.perform(delete("/issues/{issueId}/labels/{labelId}", issueId, labelId))
-                .andExpect(status().isNotFound())                       // 404
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("IssueLabelNotFound"))
-                .andExpect(jsonPath("$.error.message").value("이 이슈에 해당 라벨 매핑이 없습니다."));
-
-        Mockito.verify(issueLabelService).deleteLabelFromIssue(issueId, labelId);
-    }
-
 }

--- a/src/test/java/com/issueDive/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/issueDive/exception/GlobalExceptionHandlerTest.java
@@ -97,7 +97,7 @@ public class GlobalExceptionHandlerTest {
 
         String body = """
                 {
-                  "username": "alice@test.com",
+                  "email": "alice@test.com",
                   "password": "wrong"
                 }
                 """;


### PR DESCRIPTION
## 연관된 이슈
> #54 , #45 

</br>

## 작업 내용
> 기존 API의 컨트롤러 계층에 하드코딩 되어 있던 임시 사용자 ID 로직을 제거하고, Spring Security와 JWT 토큰을 기반으로 한 실제 사용자 인증 로직을 적용했습니다.
> 이와 함께, 변경된 인증 방식이 실제 운영 환경과 동일하게 동작하도록 모든 컨트롤러 테스트 코드를 리팩토링하여 테스트의 정확성과 신뢰도를 높였습니다.

### 주요 변경 사항
**1. 애플리케이션 코드 변경**
- IssueController, CommentController 등에서 하드코딩된 사용자 ID(1L)를 제거했습니다.
- @AuthenticationPrincipal을 사용하여 현재 인증된 사용자의 정보를 컨트롤러가 직접 받아오도록 수정했습니다.

**2. 테스트 코드 리팩토링**
- 모든 컨트롤러 테스트(@WebMvcTest)에서 보안 필터를 활성화했습니다 (addFilters=false 제거).
- @WithMockUser를 테스트 클래스 레벨에 적용하여 모든 테스트가 인증된 상태에서 실행되도록 변경했습니다.
- 상태를 변경하는(POST, PATCH, DELETE) 요청 테스트에 .with(csrf())를 추가하여 CSRF 검증을 통과하도록 수정했습니다.
- 각 컨트롤러가 의존하는 UserService 등의 Mock Bean 설정을 실제 인증 로직에 맞게 업데이트했습니다.

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
