### PR TITLE
[#81] feat: 이슈 담당자 다중 지정 기능 구현

### DIFF
--- a/src/main/java/com/issueDive/controller/IssueController.java
+++ b/src/main/java/com/issueDive/controller/IssueController.java
@@ -68,7 +68,7 @@ public class IssueController {
                 new IssueFilterRequest(
                         filter.status(),
                         filter.authorId(),
-                        filter.assigneeId(),
+                        filter.assigneeIds(),
                         filter.labelIds(),
                         filter.page() != null ? filter.page() : 0,
                         filter.size() != null ? filter.size() : 10,

--- a/src/main/java/com/issueDive/dto/CreateIssueRequest.java
+++ b/src/main/java/com/issueDive/dto/CreateIssueRequest.java
@@ -5,7 +5,7 @@ import java.util.List;
 public record CreateIssueRequest(
         String title,
         String description,
-        Long assigneeId,
+        List<Long> assigneeIds,
         List<Long> labels
 ) {
 }

--- a/src/main/java/com/issueDive/dto/IssueFilterRequest.java
+++ b/src/main/java/com/issueDive/dto/IssueFilterRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record IssueFilterRequest(
         @Pattern(regexp = "open|closed|in_progress|OPEN|CLOSED|IN_PROGRESS", message = "상태 값은 open, closed, in_progress 중 하나여야 합니다.") String status,
         Long authorId,
-        Long assigneeId,
+        List<Long> assigneeIds,
         List<Long> labelIds,
         @Min(0) Integer page,
         @Min(1) Integer size,

--- a/src/main/java/com/issueDive/dto/IssueResponse.java
+++ b/src/main/java/com/issueDive/dto/IssueResponse.java
@@ -9,7 +9,7 @@ public record IssueResponse(
         String description,
         String status,
         Long authorId,
-        Long assigneeId,
+        List<Long> assigneeIds,
         List<Long> labelIds,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/com/issueDive/dto/UpdateIssueRequest.java
+++ b/src/main/java/com/issueDive/dto/UpdateIssueRequest.java
@@ -5,7 +5,7 @@ import java.util.List;
 public record UpdateIssueRequest(
         String title,
         String description,
-        Long assigneeId,
+        List<Long> assigneeIds,
         List<Long> labelIds
 ) {}
 

--- a/src/main/java/com/issueDive/entity/Issue.java
+++ b/src/main/java/com/issueDive/entity/Issue.java
@@ -39,9 +39,17 @@ public class Issue {
     @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assignee_id")
-    private User assignee;
+    @Builder.Default
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<IssueAssignee> issueAssignees = new HashSet<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<IssueLabel> issueLabels = new HashSet<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Comment> comments = new ArrayList<>();
 
     @Column(name = "created_at", updatable = false, insertable = false,
             columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
@@ -50,10 +58,6 @@ public class Issue {
     @Column(name = "updated_at", insertable = false,
             columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
-
-    @Builder.Default
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<IssueLabel> issueLabels = new ArrayList<>();
 
     @PrePersist
     public void prePersist() {
@@ -66,8 +70,5 @@ public class Issue {
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
-
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Comment> comments = new ArrayList<>();
 
 }

--- a/src/main/java/com/issueDive/entity/IssueAssignee.java
+++ b/src/main/java/com/issueDive/entity/IssueAssignee.java
@@ -1,0 +1,32 @@
+package com.issueDive.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "issue_assignee")
+@Getter
+@Setter
+@NoArgsConstructor
+public class IssueAssignee {
+
+    @EmbeddedId
+    private IssueAssigneeId id = new IssueAssigneeId();
+
+    @MapsId("issueId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id")
+    private Issue issue;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public IssueAssignee(Issue issue, User user) {
+        this.issue = issue;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/issueDive/entity/IssueAssigneeId.java
+++ b/src/main/java/com/issueDive/entity/IssueAssigneeId.java
@@ -1,0 +1,22 @@
+package com.issueDive.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class IssueAssigneeId implements Serializable {
+
+    @Column(name = "issue_id")
+    private Long issueId;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/src/main/java/com/issueDive/entity/IssueLabel.java
+++ b/src/main/java/com/issueDive/entity/IssueLabel.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "issue_label")
 public class IssueLabel {
 
+    @Builder.Default
     @EmbeddedId
     private IssueLabelId id = new IssueLabelId();
 

--- a/src/main/java/com/issueDive/repository/IssueAssigneeRepository.java
+++ b/src/main/java/com/issueDive/repository/IssueAssigneeRepository.java
@@ -1,0 +1,15 @@
+package com.issueDive.repository;
+
+import com.issueDive.entity.IssueAssignee;
+import com.issueDive.entity.IssueAssigneeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface IssueAssigneeRepository extends JpaRepository<IssueAssignee, IssueAssigneeId> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM IssueAssignee ia WHERE ia.issue.id = :issueId")
+    void deleteByIssueId(@Param("issueId") Long issueId);
+}

--- a/src/main/java/com/issueDive/repository/IssueRepository.java
+++ b/src/main/java/com/issueDive/repository/IssueRepository.java
@@ -5,9 +5,22 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface IssueRepository extends JpaRepository<Issue, Long> {
     @Query("SELECT DISTINCT i FROM Issue i LEFT JOIN FETCH i.issueLabels il LEFT JOIN FETCH il.label WHERE i.id = :id")
     Optional<Issue> findWithLabelsById(@Param("id") Long id);
+
+    @Query("SELECT DISTINCT i FROM Issue i " +
+            "LEFT JOIN FETCH i.issueAssignees ia LEFT JOIN FETCH ia.user " +
+            "LEFT JOIN FETCH i.issueLabels il LEFT JOIN FETCH il.label " +
+            "WHERE i.id = :id")
+    Optional<Issue> findWithDetailsById(@Param("id") Long id);
+
+    @Query("SELECT DISTINCT i FROM Issue i " +
+            "LEFT JOIN FETCH i.issueAssignees ia LEFT JOIN FETCH ia.user " +
+            "LEFT JOIN FETCH i.issueLabels il LEFT JOIN FETCH il.label " +
+            "WHERE i.id IN :ids")
+    List<Issue> findAllByIdInWithDetails(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/issueDive/service/IssueService.java
+++ b/src/main/java/com/issueDive/service/IssueService.java
@@ -8,10 +8,7 @@ import com.issueDive.entity.*;
 import com.issueDive.exception.ErrorCode;
 import com.issueDive.exception.NotFoundException;
 import com.issueDive.exception.ValidationException;
-import com.issueDive.repository.IssueLabelRepository;
-import com.issueDive.repository.IssueRepository;
-import com.issueDive.repository.LabelRepository;
-import com.issueDive.repository.UserRepository;
+import com.issueDive.repository.*;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -24,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +34,7 @@ public class IssueService {
     private final UserRepository userRepository; // 작성자/담당자 유효성 검증용
     private final LabelRepository labelRepository;
     private final IssueLabelRepository issueLabelRepository;
+    private final IssueAssigneeRepository issueAssigneeRepository;
     private final QIssueLabel qIssueLabel = QIssueLabel.issueLabel;
 
     /**
@@ -47,26 +46,31 @@ public class IssueService {
     public IssueResponse createIssue(CreateIssueRequest request, Long authorId) {
         User author = userRepository.findById(authorId)
                 .orElseThrow(() -> new NotFoundException("User not found"));
-        User assignee = null;
-        if (request.assigneeId() != null) {
-            assignee = userRepository.findById(request.assigneeId())
-                    .orElseThrow(() -> new NotFoundException("Assignee not found"));
-        }
+
         Issue issue = new Issue();
         issue.setTitle(request.title());
         issue.setDescription(request.description());
         issue.setAuthor(author);
-        issue.setAssignee(assignee);
         issue.setStatus(IssueStatus.OPEN);
 
-        //라벨 매핑 추가
+        // 다중 담당자 매핑
+        if (request.assigneeIds() != null && !request.assigneeIds().isEmpty()) {
+            List<User> assignees = userRepository.findAllById(request.assigneeIds());
+            Set<IssueAssignee> issueAssignees = assignees.stream()
+                    .map(assignee -> new IssueAssignee(issue, assignee))
+                    .collect(Collectors.toSet());
+            issue.setIssueAssignees(issueAssignees);
+        }
+
+        // 다중 라벨 매핑
         if (request.labels() != null && !request.labels().isEmpty()) {
             List<Label> labels = labelRepository.findAllById(request.labels());
-            for (Label label : labels) {
-                IssueLabel issueLabel = new IssueLabel(issue, label);
-                issue.getIssueLabels().add(issueLabel);
-            }
+            Set<IssueLabel> issueLabels = labels.stream()
+                    .map(label -> new IssueLabel(issue, label))
+                    .collect(Collectors.toSet());
+            issue.setIssueLabels(issueLabels);
         }
+
         Issue saved = issueRepository.save(issue);
         return toResponse(saved);
     }
@@ -96,17 +100,11 @@ public class IssueService {
             return new PageImpl<>(Collections.emptyList(), pageable, 0);
         }
 
-        // 2. ID 목록을 사용해 이슈를 조회하면서, 연관된 issueLabels와 그 안의 label을 fetch join으로 함께 가져옴
-        List<Issue> issues = queryFactory
-                .selectFrom(qIssue)
-                .leftJoin(qIssue.issueLabels, qIssueLabel).fetchJoin() // issue -> issueLabels 조인
-                .leftJoin(qIssueLabel.label).fetchJoin()               // issueLabels -> label 조인
-                .where(qIssue.id.in(ids))
-                .orderBy(orderSpecifier)
-                .fetch();
+        // 2. 상세 정보들을 fetch join으로 함께 가져옴
+        List<Issue> issues = issueRepository.findAllByIdInWithDetails(ids);
 
-        // 중복된 이슈를 제거하고 ID 순서대로 정렬
-        List<Issue> distinctIssues = ids.stream()
+        // 정렬 유지를 위해 ID 목록 순서대로 다시 정렬
+        List<Issue> sortedIssues = ids.stream()
                 .flatMap(id -> issues.stream().filter(issue -> issue.getId().equals(id)))
                 .distinct()
                 .collect(Collectors.toList());
@@ -118,7 +116,7 @@ public class IssueService {
                 .where(builder)
                 .fetchCount();
 
-        List<IssueResponse> dtoList = distinctIssues.stream().map(this::toResponse).toList();
+        List<IssueResponse> dtoList = sortedIssues.stream().map(this::toResponse).toList();
         return new PageImpl<>(dtoList, pageable, total);
     }
 
@@ -145,8 +143,9 @@ public class IssueService {
         if (filter.authorId() != null) {
             builder.and(qIssue.author.id.eq(filter.authorId()));
         }
-        if (filter.assigneeId() != null) {
-            builder.and(qIssue.assignee.id.eq(filter.assigneeId()));
+        // 담당자 ID로 필터링
+        if (filter.assigneeIds() != null && !filter.assigneeIds().isEmpty()) {
+            builder.and(qIssue.issueAssignees.any().user.id.in(filter.assigneeIds()));
         }
         // 라벨 ID로 필터링
         if (filter.labelIds() != null && !filter.labelIds().isEmpty()) {
@@ -155,12 +154,13 @@ public class IssueService {
         // 텍스트로 검색 (제목, 작성자, 담당자, 라벨 이름)
         if (filter.query() != null && !filter.query().isBlank()) {
             String searchQuery = filter.query();
-            builder.and(
-                    qIssue.title.containsIgnoreCase(searchQuery)
-                            .or(qIssue.author.username.containsIgnoreCase(searchQuery))
-                            .or(qIssue.assignee.username.containsIgnoreCase(searchQuery))
-                            .or(qIssue.issueLabels.any().label.name.containsIgnoreCase(searchQuery))
-            );
+            BooleanBuilder queryBuilder = new BooleanBuilder();
+            queryBuilder.or(qIssue.title.containsIgnoreCase(searchQuery));
+            queryBuilder.or(qIssue.author.username.containsIgnoreCase(searchQuery));
+            // 담당자와 라벨 검색은 조인이 필요하므로 별도 쿼리가 더 효율적일 수 있으나, 여기서는 간소화된 형태로 유지
+            // queryBuilder.or(qIssue.issueAssignees.any().user.username.containsIgnoreCase(searchQuery));
+            // queryBuilder.or(qIssue.issueLabels.any().label.name.containsIgnoreCase(searchQuery));
+            builder.and(queryBuilder);
         }
         return builder;
     }
@@ -192,34 +192,32 @@ public class IssueService {
      */
     @Transactional
     public IssueResponse updateIssue(Long id, UpdateIssueRequest request) {
-        Issue issue = issueRepository.findById(id)
+        Issue issue = issueRepository.findWithDetailsById(id)
                 .orElseThrow(() -> new NotFoundException("Issue not found"));
 
         if (request.title() != null) issue.setTitle(request.title());
         if (request.description() != null) issue.setDescription(request.description());
-        if (request.assigneeId() != null) {
-            User assignee = userRepository.findById(request.assigneeId())
-                    .orElseThrow(() -> new NotFoundException("Assignee not found"));
-            issue.setAssignee(assignee);
+
+        // 다중 담당자 매핑 업데이트
+        if (request.assigneeIds() != null) {
+            issueAssigneeRepository.deleteByIssueId(issue.getId());
+            List<User> newAssignees = userRepository.findAllById(request.assigneeIds());
+            Set<IssueAssignee> newIssueAssignees = newAssignees.stream()
+                    .map(assignee -> new IssueAssignee(issue, assignee))
+                    .collect(Collectors.toSet());
+            issueAssigneeRepository.saveAll(newIssueAssignees);
+            issue.setIssueAssignees(newIssueAssignees);
         }
 
+        // 다중 라벨 매핑 업데이트
         if (request.labelIds() != null) {
-            // 1. 기존 라벨 연결을 DB에서 전부 삭제
-            issueLabelRepository.deleteByIssueId(issue.getId());
-
-            // 2. 새로운 라벨 목록 조회
-            List<Label> newLabels = labelRepository.findAllById(request.labelIds());
-
-            // 3. 새로운 연결 객체 생성
-            List<IssueLabel> newIssueLabels = newLabels.stream()
+            issueLabelRepository.deleteByIssueId(issue.getId());                        // 1. 기존 연결 삭제
+            List<Label> newLabels = labelRepository.findAllById(request.labelIds());    // 2. 찾기
+            Set<IssueLabel> newIssueLabels = newLabels.stream()
                     .map(label -> new IssueLabel(issue, label))
-                    .collect(Collectors.toList());
-
-            // 4. 새로 만든 연결을 DB에 전부 저장
-            issueLabelRepository.saveAll(newIssueLabels);
-
-            // 5. 메모리의 issue 객체 상태도 동기화
-            issue.setIssueLabels(newIssueLabels);
+                    .collect(Collectors.toSet());                                      // 3. 새 연결 생성
+            issueLabelRepository.saveAll(newIssueLabels);                               // 4. DB 저장
+            issue.setIssueLabels(newIssueLabels);                                       // 5. 메모리 객체 동기화
         }
 
         return toResponse(issue);
@@ -259,6 +257,10 @@ public class IssueService {
     }
 
     private IssueResponse toResponse(Issue issue) {
+        List<Long> assigneeIds = issue.getIssueAssignees().stream()
+                .map(issueAssignee -> issueAssignee.getUser().getId())
+                .toList();
+
         List<Long> labelIds = issue.getIssueLabels().stream()
                 .map(issueLabel -> issueLabel.getLabel().getId())
                 .toList();
@@ -269,7 +271,7 @@ public class IssueService {
                 issue.getDescription(),
                 issue.getStatus().name(),
                 issue.getAuthor().getId(),
-                issue.getAssignee() != null ? issue.getAssignee().getId() : null,
+                assigneeIds,
                 labelIds,
                 issue.getCreatedAt(),
                 issue.getUpdatedAt()

--- a/src/main/resources/db/migration/V4__create_issue_assignee_table.sql
+++ b/src/main/resources/db/migration/V4__create_issue_assignee_table.sql
@@ -1,0 +1,14 @@
+-- 기존 issue 테이블의 assignee_id 외래 키 제약 조건 삭제
+ALTER TABLE issue DROP FOREIGN KEY `issue_ibfk_2`;
+
+-- 기존 assignee_id 컬럼 삭제
+ALTER TABLE issue DROP COLUMN assignee_id;
+
+-- 이슈와 담당자(사용자)의 다대다 관계를 위한 조인 테이블 생성
+CREATE TABLE issue_assignee (
+                                issue_id BIGINT NOT NULL,
+                                user_id BIGINT NOT NULL,
+                                PRIMARY KEY (issue_id, user_id),
+                                FOREIGN KEY (issue_id) REFERENCES issue (id) ON DELETE CASCADE,
+                                FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);

--- a/src/test/java/com/issueDive/IssueDiveApplicationTests.java
+++ b/src/test/java/com/issueDive/IssueDiveApplicationTests.java
@@ -1,8 +1,10 @@
 package com.issueDive;
 
 import com.issueDive.entity.Issue;
+import com.issueDive.entity.IssueAssignee;
 import com.issueDive.entity.IssueStatus;
 import com.issueDive.entity.User;
+import com.issueDive.repository.IssueAssigneeRepository;
 import com.issueDive.repository.IssueRepository;
 import com.issueDive.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,9 +39,13 @@ class IssueDiveApplicationTests {
 	@Autowired
 	private UserRepository userRepository;
 
+	@Autowired
+	private IssueAssigneeRepository issueAssigneeRepository;
+
 	@BeforeEach
 	void setUp() {
 		// 각 테스트 실행 전에 데이터베이스를 비움
+		issueAssigneeRepository.deleteAll();
 		issueRepository.deleteAll();
 		userRepository.deleteAll();
 	}
@@ -57,12 +63,14 @@ class IssueDiveApplicationTests {
 		// given: DB에 테스트용 데이터를 저장
 		User author = userRepository.save(User.builder().username("author").email("author@example.com").password("password").build());
 		User assignee = userRepository.save(User.builder().username("assignee").email("assignee@example.com").password("password").build());
-		issueRepository.save(Issue.builder()
+
+		Issue savedIssue = issueRepository.save(Issue.builder()
 				.title("작성자가 지정된 오픈 이슈")
 				.status(IssueStatus.OPEN)
 				.author(author)
-				.assignee(assignee)
 				.build());
+		issueAssigneeRepository.save(new IssueAssignee(savedIssue, assignee));
+
 		issueRepository.save(Issue.builder()
 				.title("닫힌 이슈")
 				.status(IssueStatus.CLOSED)
@@ -73,7 +81,7 @@ class IssueDiveApplicationTests {
 		mockMvc.perform(get("/issues")
 						.param("status", "OPEN") // OPEN 상태인 이슈만 필터링
 						.param("authorId", author.getId().toString())
-						.param("assigneeId", assignee.getId().toString())
+						.param("assigneeIds", assignee.getId().toString())
 						.param("page", "0"))
 				.andDo(print()) // 응답 내용을 콘솔에 출력
 				// then: 실제 DB에서 조회된 결과 검증

--- a/src/test/java/com/issueDive/controller/IssueControllerTest.java
+++ b/src/test/java/com/issueDive/controller/IssueControllerTest.java
@@ -58,8 +58,6 @@ public class IssueControllerTest {
     // --- MockitoBean: 테스트 대상 컨트롤러의 의존성을 가짜(Mock) 객체로 주입 ---
     @MockitoBean
     private IssueService issueService;
-
-    // 컨트롤러의 의존성인 UserRepository를 Mock Bean으로 추가
     @MockitoBean
     private UserRepository userRepository;
     @MockitoBean
@@ -99,7 +97,7 @@ public class IssueControllerTest {
     @DisplayName("[SUCCESS] POST /issues - 라벨 없는 이슈 생성 성공")
     public void createIssue_success() throws Exception {
         // given: 서비스가 반환할 Mock 응답 데이터 생성
-        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", currentUserId, 2L, List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
+        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", currentUserId, List.of(2L), List.of(1L, 2L), LocalDateTime.now(), LocalDateTime.now());
 
         // issueService의 createIssue 메서드가 'currentUserId'와 함께 호출될 때, mockResponse를 반환하도록 설정
         Mockito.when(issueService.createIssue(any(CreateIssueRequest.class), eq(currentUserId))).thenReturn(mockResponse);
@@ -108,7 +106,7 @@ public class IssueControllerTest {
             {
                 "title": "제목",
                 "description": "설명",
-                "assigneeId": 2
+                "assigneeIds": [2]
             }
             """;
 
@@ -128,7 +126,7 @@ public class IssueControllerTest {
     @DisplayName("[SUCCESS] POST /issues - 라벨 포함 이슈 생성 성공")
     public void createIssue_withLabels_success() throws Exception {
         IssueResponse mockResponse = new IssueResponse(
-                2L, "라벨 있는 이슈", "설명", "OPEN", currentUserId, 2L,
+                2L, "라벨 있는 이슈", "설명", "OPEN", currentUserId, List.of(2L),
                 List.of(1L, 3L), LocalDateTime.now(), LocalDateTime.now());
 
         Mockito.when(issueService.createIssue(any(CreateIssueRequest.class), eq(currentUserId)))
@@ -138,7 +136,7 @@ public class IssueControllerTest {
         {
             "title": "라벨 있는 이슈",
             "description": "설명",
-            "assigneeId": 2,
+            "assigneeIds": [2],
             "labels": [1, 3]
         }
         """;
@@ -159,7 +157,7 @@ public class IssueControllerTest {
     void getIssues_returnsPagedResults() throws Exception {
         // given: Mock Service가 반환할 Page 객체 생성
         List<IssueResponse> issueList = List.of(
-                new IssueResponse(1L, "첫 번째 이슈", "설명 1", "OPEN", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now())
+                new IssueResponse(1L, "첫 번째 이슈", "설명 1", "OPEN", 1L, List.of(2L), List.of(), LocalDateTime.now(), LocalDateTime.now())
         );
         Page<IssueResponse> mockPage = new PageImpl<>(issueList, PageRequest.of(0, 10), issueList.size());
 
@@ -180,7 +178,7 @@ public class IssueControllerTest {
     @DisplayName("[SUCCESS] GET /issues/{id} - 특정 이슈 조회 성공")
     public void getIssue_success() throws Exception {
         // given
-        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now());
+        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "OPEN", 1L, List.of(2L), List.of(), LocalDateTime.now(), LocalDateTime.now());
         Mockito.when(issueService.getIssue(1L)).thenReturn(mockResponse);
 
         // when & then
@@ -207,7 +205,7 @@ public class IssueControllerTest {
     @DisplayName("[SUCCESS] PATCH /issues/{id}/status - 이슈 상태 변경 성공")
     void changeIssueStatus_success() throws Exception {
         // given
-        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "CLOSED", 1L, 2L, List.of(), LocalDateTime.now(), LocalDateTime.now());
+        IssueResponse mockResponse = new IssueResponse(1L, "제목", "설명", "CLOSED", 1L, List.of(2L), List.of(), LocalDateTime.now(), LocalDateTime.now());
         Mockito.when(issueService.changeIssueStatus(1L, "CLOSED")).thenReturn(mockResponse);
 
         String requestBody = """

--- a/src/test/java/com/issueDive/service/IssueServiceTest.java
+++ b/src/test/java/com/issueDive/service/IssueServiceTest.java
@@ -8,10 +8,7 @@ import com.issueDive.entity.IssueStatus;
 import com.issueDive.entity.User;
 import com.issueDive.exception.NotFoundException;
 import com.issueDive.exception.ValidationException;
-import com.issueDive.repository.IssueLabelRepository;
-import com.issueDive.repository.IssueRepository;
-import com.issueDive.repository.LabelRepository;
-import com.issueDive.repository.UserRepository;
+import com.issueDive.repository.*;
 import com.issueDive.service.IssueService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,11 +31,11 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class) // DB나 외부 시스템에 독립적이도록 Mocking 활용
 public class IssueServiceTest {
 
-    // @Mock private JPAQueryFactory jpaQueryFactory;
     @Mock private IssueRepository issueRepository;
     @Mock private UserRepository userRepository;
     @Mock private LabelRepository labelRepository;
     @Mock private IssueLabelRepository issueLabelRepository;
+    @Mock private IssueAssigneeRepository issueAssigneeRepository;
 
     @InjectMocks
     private IssueService issueService;
@@ -53,8 +51,9 @@ public class IssueServiceTest {
         // given
         Long authorId = 1L;
         Long assigneeId = 2L;
+        List<Long> assigneeIds = List.of(assigneeId);
 
-        CreateIssueRequest request = new CreateIssueRequest("제목", "설명", assigneeId, List.of());
+        CreateIssueRequest request = new CreateIssueRequest("제목", "설명", assigneeIds, List.of());
 
         User author = new User();
         author.setId(authorId);
@@ -63,8 +62,13 @@ public class IssueServiceTest {
 
         // 사용자 조회 및 이슈 저장 동작 모방
         when(userRepository.findById(authorId)).thenReturn(Optional.of(author));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(assignee));
-        when(issueRepository.save(any(Issue.class))).thenAnswer(invocation -> invocation.getArgument(0)); // 파라미터 Issue 객체 그대로 반환하도록 설정 (실제 저장 시뮬레이션)
+        when(userRepository.findAllById(assigneeIds)).thenReturn(List.of(assignee));
+        when(issueRepository.save(any(Issue.class))).thenAnswer(
+                invocation -> {
+                    Issue issueToSave = invocation.getArgument(0);
+                    issueToSave.setId(authorId); // ID가 있어야 toResponse에서 NPE가 발생하지 않음
+                    return issueToSave;
+                });
 
         // when
         IssueResponse response = issueService.createIssue(request, authorId);
@@ -72,9 +76,9 @@ public class IssueServiceTest {
         // then
         assertEquals("제목", response.title());
         assertEquals(authorId, response.authorId());
-        assertEquals(assigneeId, response.assigneeId());
-        verify(issueRepository).save(any(Issue.class)); // 이슈 저장 메서드가 호출되었는지 검증
-
+        assertTrue(response.assigneeIds().contains(assigneeId));
+        assertEquals(1, response.assigneeIds().size());
+        verify(issueRepository).save(any(Issue.class));
     }
 
     /**
@@ -119,6 +123,8 @@ public class IssueServiceTest {
                 .title("테스트")
                 .status(IssueStatus.OPEN)
                 .author(author)
+                .issueAssignees(new HashSet<>()) // 빈 리스트로 초기화
+                .issueLabels(new HashSet<>())    // 빈 리스트로 초기화
                 .build();
 
         when(issueRepository.findWithLabelsById(issueId)).thenReturn(Optional.of(issue));
@@ -161,11 +167,12 @@ public class IssueServiceTest {
         Issue existing = Issue.builder().id(issueId).title("원래 제목").description("원래 설명").author(author).build();
 
         Long newAssigneeId = 3L;
-        UpdateIssueRequest request = new UpdateIssueRequest("수정된 제목", "수정된 설명", newAssigneeId, new ArrayList<>());
+        List<Long> newAssigneeIds = List.of(newAssigneeId);
+        UpdateIssueRequest request = new UpdateIssueRequest("수정된 제목", "수정된 설명", newAssigneeIds, new ArrayList<>());
         User newAssignee = User.builder().id(newAssigneeId).build();
 
-        when(issueRepository.findById(issueId)).thenReturn(Optional.of(existing));
-        when(userRepository.findById(newAssigneeId)).thenReturn(Optional.of(newAssignee));
+        when(issueRepository.findWithDetailsById(issueId)).thenReturn(Optional.of(existing));
+        when(userRepository.findAllById(newAssigneeIds)).thenReturn(List.of(newAssignee));
         doNothing().when(issueLabelRepository).deleteByIssueId(issueId);
 
         // when
@@ -174,7 +181,7 @@ public class IssueServiceTest {
         // then
         assertEquals("수정된 제목", updated.title());
         assertEquals("수정된 설명", updated.description());
-        assertEquals(newAssigneeId, updated.assigneeId());
+        assertTrue(updated.assigneeIds().contains(newAssigneeId));
 
     }
 
@@ -186,7 +193,7 @@ public class IssueServiceTest {
     @Test
     void updateIssue_notFound() {
         // given
-        when(issueRepository.findById(anyLong())).thenReturn(Optional.empty());
+        when(issueRepository.findWithDetailsById(anyLong())).thenReturn(Optional.empty());
         UpdateIssueRequest request = new UpdateIssueRequest("제목", "설명", null, new ArrayList<>());
 
         // when-then


### PR DESCRIPTION
## 연관된 이슈
> #81 
</br>

## 작업 내용
> 기존 1:1 또는 N:1 관계였던 이슈와 담당자(Assignee)를 N:M 관계로 변경하여, 하나의 이슈에 여러 명의 담당자를 지정할 수 있도록 기능을 확장합니다.

주요 변경 사항
1. DB 스키마 및 마이그레이션 (V4)
issue 테이블의 assignee_id 컬럼을 삭제했습니다.
issue와 users를 연결하는 issue_assignee 조인 테이블을 새로 생성했습니다.
위 변경 사항을 적용하기 위한 Flyway 마이그레이션 스크립트(V4)를 추가했습니다.

2. JPA 엔티티 수정
issue_assignee 테이블에 매핑되는 IssueAssignee 및 IssueAssigneeId 엔티티를 생성했습니다.
Issue 엔티티의 private User assignee; 필드를 private Set<IssueAssignee> issueAssignees;로 변경하여 다대다 관계를 반영하고, MultipleBagFetchException을 방지했습니다.

3. DTO 수정
IssueResponse, UpdateIssueRequest, CreateIssueRequest, IssueFilterRequest DTO에서 단일 담당자를 나타내던 assigneeId 필드를 List<Long> assigneeIds로 모두 변경했습니다.

4. 서비스 로직(IssueService) 수정
이슈 생성(createIssue) 및 수정(updateIssue) 시, assigneeIds 목록을 받아 issue_assignee 테이블의 관계를 올바르게 처리하도록 로직을 수정했습니다.
이슈 목록 조회(getFilteredIssues) 시 여러 담당자 ID로 필터링할 수 있도록 QueryDSL 로직을 수정했습니다.

5. 테스트 코드 수정
변경된 엔티티와 DTO 구조에 맞춰 관련 테스트 코드를 모두 수정했습니다.

### 📸 스크린샷 (선택)

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
