### PR TITLE
[#84] feat: 이슈 상세 페이지 탐색 기능 추가

### DIFF
--- a/src/main/java/com/issueDive/controller/IssueController.java
+++ b/src/main/java/com/issueDive/controller/IssueController.java
@@ -137,10 +137,10 @@ public class IssueController {
     /**
      * 이슈 상태 변경 PATCH /issues/{id}/status
      * @param id 이슈 ID
-     * @param body { "status": "OPEN" or "CLOSED" }
+     * @param body { "status": "OPEN" or "CLOSED" or "IN_PROGRESS"}
      * @return 변경된 상태 IssueResponse 반환
      */
-    @Operation(summary = "이슈 상태 변경", description = "이슈의 상태를 'OPEN' 또는 'CLOSED'로 변경합니다. 요청 본문 예시: { \"status\": \"CLOSED\" }")
+    @Operation(summary = "이슈 상태 변경", description = "이슈의 상태를 'OPEN' 또는 'CLOSED' 또는 'IN_PROGRESS'로 변경합니다. 요청 본문 예시: { \"status\": \"CLOSED\" }")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 상태 값 (OPEN, CLOSED만 가능)", content = @Content),
@@ -174,4 +174,24 @@ public class IssueController {
         issueService.deleteIssue(id);
         return ResponseEntity.ok(ApiCommonResponse.ok(Map.of("message", "Issue " + id + " deleted successfully")));
     }
+
+    /**
+     * 현재 이슈의 필터/정렬 기준에 따른 이전 및 다음 이슈 ID 조회
+     * @param id 현재 이슈
+     * @param filter status, authorId, labelIds, page, size, sort, order
+     * @return previousIssueId, nextIssueId
+     */
+    @Operation(summary = "이슈 상세 페이지 탐색 정보 조회", description = "현재 이슈의 필터/정렬 기준에 따른 이전 및 다음 이슈 ID를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "탐색 정보 조회 성공")
+    })
+    @GetMapping("/{id}/navigation")
+    public ResponseEntity<ApiCommonResponse<IssueNavigationResponse>> getIssueNavigation(
+            @Parameter(description = "현재 이슈의 ID", required = true) @PathVariable Long id,
+            @Parameter(description = "이슈 목록 조회 시 사용된 필터 객체") @Valid IssueFilterRequest filter) {
+
+        IssueNavigationResponse navigation = issueService.getIssueNavigation(id, filter);
+        return ResponseEntity.ok(ApiCommonResponse.ok(navigation));
+    }
+
 }

--- a/src/main/java/com/issueDive/dto/IssueNavigationResponse.java
+++ b/src/main/java/com/issueDive/dto/IssueNavigationResponse.java
@@ -1,0 +1,12 @@
+package com.issueDive.dto;
+
+/**
+ * 이슈 상세 페이지에서 이전/다음 이슈 탐색을 위한 응답 DTO
+ * @param previousIssueId 이전 이슈 ID (없으면 null)
+ * @param nextIssueId 다음 이슈 ID (없으면 null)
+ */
+public record IssueNavigationResponse(
+        Long previousIssueId,
+        Long nextIssueId
+) {
+}

--- a/src/main/java/com/issueDive/service/IssueService.java
+++ b/src/main/java/com/issueDive/service/IssueService.java
@@ -1,9 +1,6 @@
 package com.issueDive.service;
 
-import com.issueDive.dto.CreateIssueRequest;
-import com.issueDive.dto.IssueFilterRequest;
-import com.issueDive.dto.IssueResponse;
-import com.issueDive.dto.UpdateIssueRequest;
+import com.issueDive.dto.*;
 import com.issueDive.entity.*;
 import com.issueDive.exception.ErrorCode;
 import com.issueDive.exception.NotFoundException;
@@ -257,6 +254,45 @@ public class IssueService {
             throw new NotFoundException("Issue not found");
         }
         issueRepository.deleteById(id);
+    }
+
+    /**
+     * 특정 필터 조건 하에서, 현재 이슈의 이전/다음 이슈 ID 조회
+     * @param currentIssueId 현재 보고 있는 이슈의 ID
+     * @param filter 목록 페이지에서 사용된 필터 및 정렬 조건
+     * @return 이전/다음 이슈 ID를 담은 DTO
+     */
+    @Transactional(readOnly = true)
+    public IssueNavigationResponse getIssueNavigation(Long currentIssueId, IssueFilterRequest filter) {
+        // 1. 목록 조회와 동일한 필터, 정렬 조건을 가져옵니다.
+        BooleanBuilder builder = createFilterBuilder(filter);
+        OrderSpecifier<?> orderSpecifier = getSortOrder(filter.sort(), filter.order());
+
+        // 2. 페이징 없이, 필터링되고 정렬된 전체 이슈 ID 목록을 조회합니다.
+        List<Long> allFilteredIds = queryFactory
+                .select(qIssue.id)
+                .from(qIssue)
+                .where(builder)
+                .orderBy(orderSpecifier)
+                .fetch();
+
+        if (allFilteredIds.isEmpty()) {
+            return new IssueNavigationResponse(null, null);
+        }
+
+        // 3. 전체 목록에서 현재 이슈 ID의 인덱스(순서)를 찾습니다.
+        int currentIndex = allFilteredIds.indexOf(currentIssueId);
+
+        if (currentIndex == -1) {
+            // 현재 이슈가 필터 조건에 맞지 않는 경우 (예: 상태가 바뀜)
+            return new IssueNavigationResponse(null, null);
+        }
+
+        // 4. 인덱스를 기준으로 이전(-1)과 다음(+1) ID를 결정합니다.
+        Long previousId = (currentIndex > 0) ? allFilteredIds.get(currentIndex - 1) : null;
+        Long nextId = (currentIndex < allFilteredIds.size() - 1) ? allFilteredIds.get(currentIndex + 1) : null;
+
+        return new IssueNavigationResponse(previousId, nextId);
     }
 
     private IssueResponse toResponse(Issue issue) {


### PR DESCRIPTION
## 연관된 이슈
> #84 

</br>

## 작업 내용
> 사용자가 이슈 목록 페이지에서 적용한 필터 및 정렬 상태를 유지한 채로, 이슈 상세 페이지 내에서 바로 '이전 이슈'와 '다음 이슈'로 이동할 수 있도록 지원하는 신규 API 엔드포인트를 구현합니다. 이를 통해 목록으로 돌아갔다가 다시 들어오는 불필요한 과정을 생략하여 프론트엔드의 사용자 경험을 크게 향상시킬 수 있습니다.
>
> `GET /issues/{id}/navigation` API 

1. IssueNavigationResponse DTO 추가:
previousIssueId: Long? 와 nextIssueId: Long? 필드를 가지는 새로운 Record DTO를 생성했습니다. (이전/다음 이슈가 없을 경우 null이 될 수 있습니다.)

3. IssueService 로직 추가:
getIssueNavigation(currentIssueId, filter) 메소드를 새로 구현했습니다.
로직 순서:
   1. 전달받은 filter 조건으로 전체 이슈 ID 목록을 정렬 순서에 맞게 조회합니다. (QueryDSL 사용, 페이징 제외)
   2. 조회된 ID 목록 전체에서 currentIssueId의 인덱스(순서)를 찾습니다.
   3. index - 1 위치의 ID를 previousIssueId로, index + 1 위치의 ID를 nextIssueId로 설정합니다. (인덱스가 범위를 벗어날 경우 null로 안전하게 처리)
   4. IssueNavigationResponse DTO에 담아 반환합니다.

4. IssueController 엔드포인트 추가:
GET /issues/{id}/navigation 엔드포인트를 추가하여, 프론트엔드가 기존 목록 조회 시 사용하던 모든 필터(IssueFilterRequest)를 쿼리 파라미터로 넘겨 탐색 정보를 요청할 수 있도록 했습니다.

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
