### PR TITLE
[#86] fix: 사용 중인 라벨 삭제 시 외래 키 제약 조건 오류 발생 문제 해결

### DIFF
--- a/src/main/java/com/issueDive/repository/IssueLabelRepository.java
+++ b/src/main/java/com/issueDive/repository/IssueLabelRepository.java
@@ -15,7 +15,7 @@ public interface IssueLabelRepository extends JpaRepository<IssueLabel, IssueLab
     boolean existsByIssueAndLabel(Issue issue, Label label);
     void deleteByIssueAndLabel(Issue issue, Label label);
     List<IssueLabel> findAllByIssue(Issue issue);
-    void deleteByLabelId(Long labelId);
+//    void deleteByLabelId(Long labelId);
     long countByLabel(Label label);
 
     boolean existsByLabelId(Long labelId);
@@ -23,5 +23,9 @@ public interface IssueLabelRepository extends JpaRepository<IssueLabel, IssueLab
     @Modifying(clearAutomatically = true)   // db 데이터 변경, 이 쿼리가 실행된 후 영속성 컨텍스트 자동 초기화
     @Query("DELETE FROM IssueLabel il WHERE il.issue.id = :issueId")
     void deleteByIssueId(@Param("issueId") Long issueId);
+
+    @Modifying
+    @Query("DELETE FROM IssueLabel il WHERE il.label.id = :labelId")
+    void deleteByLabelId(@Param("labelId") Long labelId);
 
 }

--- a/src/main/java/com/issueDive/service/LabelService.java
+++ b/src/main/java/com/issueDive/service/LabelService.java
@@ -92,10 +92,9 @@ public class LabelService {
             throw new LabelNotFoundException("Label not found: id=" + id);
         }
 
-        //이슈 라벨 매핑이 있는지 검사 후, 매핑이 있을 시에만 삭제하도록 바꿔야 함
-        if (!issueLabelRepository.existsByLabelId(id)){
-            issueLabelRepository.deleteByLabelId(id);
-        }
+        // 부모(label) 삭제 전에, 먼저 자식 테이블(issue_label)에서 해당 라벨을 사용하는 모든 연결 삭제
+        // (존재 여부를 확인할 필요 없이 그냥 삭제함. 없으면 아무 일도 일어나지 않음.)
+        issueLabelRepository.deleteByLabelId(id);
 
         labelRepository.deleteById(id);
     }


### PR DESCRIPTION
## 연관된 이슈
> #86 

</br>

## 작업 내용
> 이슈에 할당되어 사용 중인 라벨을 삭제할 때 발생하던 데이터베이스 외래 키 제약 조건 오류를 해결합니다.

label 테이블(부모)을 issue_label 테이블(자식)이 참조하는 상황에서, 부모를 먼저 삭제하려 시도하여 DataIntegrityViolationException이 발생.

-> LabelService의 deleteLabel 메소드 수정해 해결함.
(labelRepository.deleteById() 호출 전에, issueLabelRepository.deleteByLabelId()를 먼저 호출하는 로직 추가)

### PR 유형
> 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
