### PR TITLE
[#67] fix: 이슈 검색 시 라벨 및 담당자 이름 포함

### DIFF
--- a/src/main/java/com/issueDive/service/IssueService.java
+++ b/src/main/java/com/issueDive/service/IssueService.java
@@ -158,8 +158,8 @@ public class IssueService {
             queryBuilder.or(qIssue.title.containsIgnoreCase(searchQuery));
             queryBuilder.or(qIssue.author.username.containsIgnoreCase(searchQuery));
             // 담당자와 라벨 검색은 조인이 필요하므로 별도 쿼리가 더 효율적일 수 있으나, 여기서는 간소화된 형태로 유지
-            // queryBuilder.or(qIssue.issueAssignees.any().user.username.containsIgnoreCase(searchQuery));
-            // queryBuilder.or(qIssue.issueLabels.any().label.name.containsIgnoreCase(searchQuery));
+             queryBuilder.or(qIssue.issueAssignees.any().user.username.containsIgnoreCase(searchQuery));
+             queryBuilder.or(qIssue.issueLabels.any().label.name.containsIgnoreCase(searchQuery));
             builder.and(queryBuilder);
         }
         return builder;


### PR DESCRIPTION
## 연관된 이슈
> #67 

</br>

## 작업 내용
> 이슈 목록 페이지의 전체 검색 기능이 라벨 이름과 담당자 이름도 포함하여 검색할 수 있도록 수정했습니다.

### 📸 스크린샷 (선택)

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

QueryDSL에서 any()를 사용한 다중 조인이 포함되어 있음. 추후 성능 문제 고려 필요합니다.

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
