### PR TITLE
[#90] feat: label 통계 기능 구현 - openCount 필드 추가

### DIFF
--- a/src/main/java/com/issueDive/dto/LabelResponse.java
+++ b/src/main/java/com/issueDive/dto/LabelResponse.java
@@ -15,16 +15,18 @@ public class LabelResponse {
     private String name;
     private String color;
     private String description;
+    private Long openCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static LabelResponse from(Label label) {
+    public static LabelResponse from(Label label, long openCount) {
 
         return LabelResponse.builder()
                 .id(label.getId())
                 .name(label.getName())
                 .color(label.getColor())
                 .description(label.getDescription())
+                .openCount(openCount)
                 .createdAt(label.getCreatedAt())
                 .updatedAt(label.getUpdatedAt())
                 .build();

--- a/src/main/java/com/issueDive/repository/IssueLabelRepository.java
+++ b/src/main/java/com/issueDive/repository/IssueLabelRepository.java
@@ -1,9 +1,6 @@
 package com.issueDive.repository;
 
-import com.issueDive.entity.Issue;
-import com.issueDive.entity.IssueLabel;
-import com.issueDive.entity.IssueLabelId;
-import com.issueDive.entity.Label;
+import com.issueDive.entity.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,8 +12,8 @@ public interface IssueLabelRepository extends JpaRepository<IssueLabel, IssueLab
     boolean existsByIssueAndLabel(Issue issue, Label label);
     void deleteByIssueAndLabel(Issue issue, Label label);
     List<IssueLabel> findAllByIssue(Issue issue);
-//    void deleteByLabelId(Long labelId);
-    long countByLabel(Label label);
+
+    long countByLabelAndIssue_Status(Label label, IssueStatus issueStatus);
 
     boolean existsByLabelId(Long labelId);
 

--- a/src/main/java/com/issueDive/service/IssueLabelService.java
+++ b/src/main/java/com/issueDive/service/IssueLabelService.java
@@ -2,10 +2,7 @@ package com.issueDive.service;
 
 import com.issueDive.dto.IssueLabelsResponse;
 import com.issueDive.dto.LabelResponse;
-import com.issueDive.entity.Issue;
-import com.issueDive.entity.IssueLabel;
-import com.issueDive.entity.IssueLabelId;
-import com.issueDive.entity.Label;
+import com.issueDive.entity.*;
 import com.issueDive.exception.IssueLabelNotFoundException;
 import com.issueDive.exception.LabelNotFoundException;
 import com.issueDive.exception.NotFoundException;
@@ -95,8 +92,8 @@ public class IssueLabelService {
         }
 
         issueLabelRepository.deleteByIssueAndLabel(issue, label);
-
-        return LabelResponse.from(label);
+        long openCount = issueLabelRepository.countByLabelAndIssue_Status(label, IssueStatus.OPEN);
+        return LabelResponse.from(label,  openCount);
     }
 
 }

--- a/src/main/java/com/issueDive/service/LabelService.java
+++ b/src/main/java/com/issueDive/service/LabelService.java
@@ -3,6 +3,7 @@ package com.issueDive.service;
 import com.issueDive.dto.CreateLabelRequest;
 import com.issueDive.dto.LabelResponse;
 import com.issueDive.dto.UpdateLabelRequest;
+import com.issueDive.entity.IssueStatus;
 import com.issueDive.entity.Label;
 import com.issueDive.exception.ErrorCode;
 import com.issueDive.exception.LabelNotFoundException;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -36,16 +38,21 @@ public class LabelService {
                         .build()
         );
 
-        return LabelResponse.from(savedLabel);
+        long openCount = issueLabelRepository.countByLabelAndIssue_Status(savedLabel, IssueStatus.OPEN);
+        return LabelResponse.from(savedLabel,  openCount);
     }
 
     //라벨 목록 조회
     @Transactional(readOnly = true)
     public List<LabelResponse> getLabels() {
+        List<Label> labels = labelRepository.findAll();
+        List<LabelResponse> responses = new ArrayList<>();
 
-        return labelRepository.findAll().stream()
-                .map(LabelResponse::from)
-                .toList();
+        for (Label label : labels) {
+            long openCount = issueLabelRepository.countByLabelAndIssue_Status(label, IssueStatus.OPEN);
+            responses.add(LabelResponse.from(label, openCount));
+        }
+        return responses;
     }
 
     //단일 라벨 조회
@@ -54,7 +61,8 @@ public class LabelService {
         Label label = labelRepository.findById(id)
                 .orElseThrow(() -> new LabelNotFoundException("Label not found: id=" + id));
 
-        return LabelResponse.from(label);
+        long openCount = issueLabelRepository.countByLabelAndIssue_Status(label, IssueStatus.OPEN);
+        return LabelResponse.from(label,  openCount);
     }
 
     //라벨 수정
@@ -81,8 +89,9 @@ public class LabelService {
         }
 
         Label updatedLabel = labelRepository.save(label);
+        long openCount = issueLabelRepository.countByLabelAndIssue_Status(label, IssueStatus.OPEN);
 
-        return LabelResponse.from(updatedLabel);
+        return LabelResponse.from(updatedLabel, openCount);
     }
 
     //라벨 삭제
@@ -98,4 +107,5 @@ public class LabelService {
 
         labelRepository.deleteById(id);
     }
+
 }

--- a/src/test/java/com/issueDive/controller/LabelControllerTest.java
+++ b/src/test/java/com/issueDive/controller/LabelControllerTest.java
@@ -62,7 +62,9 @@ class LabelControllerTest {
     @DisplayName("[SUCCESS] POST /labels - 라벨 생성 성공")
     void createLabel_success() throws Exception {
         // given: 서비스가 반환할 Mock 응답 데이터 생성
-        LabelResponse mockResponse = LabelResponse.builder().id(10L).name("bug").color("#FF0000").build();
+        LabelResponse mockResponse = LabelResponse.builder().id(10L).name("bug").color("#FF0000")
+                .openCount(0L)  //새 라벨은 openCount = 0
+                .build();
         Mockito.when(labelService.createLabel(any(CreateLabelRequest.class))).thenReturn(mockResponse);
 
         String requestBody = """
@@ -81,7 +83,8 @@ class LabelControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(10))
-                .andExpect(jsonPath("$.data.name").value("bug"));
+                .andExpect(jsonPath("$.data.name").value("bug"))
+                .andExpect(jsonPath("$.data.openCount").value(0));  //검증 추가
     }
 
     @Test
@@ -109,8 +112,8 @@ class LabelControllerTest {
     void getLabels_success() throws Exception {
         // given
         List<LabelResponse> mockList = List.of(
-                LabelResponse.builder().id(1L).name("bug").build(),
-                LabelResponse.builder().id(2L).name("feature").build()
+                LabelResponse.builder().id(1L).name("bug").openCount(2L).build(),
+                LabelResponse.builder().id(2L).name("feature").openCount(0L).build()
         );
         Mockito.when(labelService.getLabels()).thenReturn(mockList);
 
@@ -120,21 +123,26 @@ class LabelControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].name").value("bug"))
-                .andExpect(jsonPath("$.data[1].name").value("feature"));
+                .andExpect(jsonPath("$.data[0].openCount").value(2))    //count 검증 추가
+                .andExpect(jsonPath("$.data[1].name").value("feature"))
+                .andExpect(jsonPath("$.data[1].openCount").value(0));   //count 검증 추가
     }
 
     @Test
     @DisplayName("[SUCCESS] GET /labels/{labelId} - 특정 라벨 조회 성공")
     void getLabel_success() throws Exception {
         // given
-        LabelResponse mockResponse = LabelResponse.builder().id(10L).name("bug").color("#FF0000").build();
+        LabelResponse mockResponse = LabelResponse.builder().id(10L).name("bug").color("#FF0000")
+                .openCount(5L)  //OPEN이슈 5개
+                .build();
         Mockito.when(labelService.getLabel(10L)).thenReturn(mockResponse);
 
         // when & then
         mockMvc.perform(get("/labels/10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(10))
-                .andExpect(jsonPath("$.data.name").value("bug"));
+                .andExpect(jsonPath("$.data.name").value("bug"))
+                .andExpect(jsonPath("$.data.openCount").value(5));  //count 검증 추가
     }
 
     @Test
@@ -225,14 +233,17 @@ class LabelControllerTest {
         // given
         Long issueId = 1L;
         Long labelId = 20L;
-        LabelResponse mockResponse = LabelResponse.builder().id(labelId).name("feature").build();
+        LabelResponse mockResponse = LabelResponse.builder().id(labelId).name("feature")
+                .openCount(1L)  //제거 후 OPEN 이슈 1개
+                .build();
         Mockito.when(issueLabelService.deleteLabelFromIssue(issueId, labelId)).thenReturn(mockResponse);
 
         // when & then
         mockMvc.perform(delete("/issues/{issueId}/labels/{labelId}", issueId, labelId)
                         .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(labelId));
+                .andExpect(jsonPath("$.data.id").value(labelId))
+                .andExpect(jsonPath("$.data.openCount").value(1));  //count 검증 추가
 
         Mockito.verify(issueLabelService).deleteLabelFromIssue(issueId, labelId);
     }


### PR DESCRIPTION
## 연관된 이슈
> #90

</br>

## 작업 내용
> LabelResponse DTO에  openCount 필드 추가</br>
> IssueLabelRepository를 활용해 각 라벨에 OPEN 이슈 개수를 계산하도록 구현 </br>
> LabelService, IssueLabelService에서 반환하는 응답에 openCount가 포함되도록 수정</br>

## 작업 이유
> 현재 라벨 관련 API응답에는 카운트 정보가 없어서, 실제 깃허브 이슈와 차이가 있었음</br>
> 따라서 openCount를 추가하여 깃허브 이슈와 비슷하도록 바꿈</br>

### 📸 스크린샷 (선택)

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
