### PR TITLE
Fix/100 xss filter email bug

### DIFF
--- a/src/main/java/com/issueDive/config/NoXss.java
+++ b/src/main/java/com/issueDive/config/NoXss.java
@@ -1,0 +1,16 @@
+package com.issueDive.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 이 어노테이션이 선언된 DTO의 필드는
+ * XSS 방지 필터링(Sanitization)을 적용하지 않습니다.
+ * (이메일, 비밀번호 등 특수문자가 필요한 필드에 사용)
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoXss {
+}

--- a/src/main/java/com/issueDive/config/XssSanitizerConfig.java
+++ b/src/main/java/com/issueDive/config/XssSanitizerConfig.java
@@ -1,8 +1,10 @@
 package com.issueDive.config;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
@@ -35,7 +37,7 @@ public class XssSanitizerConfig {
     /**
      * 문자열 값을 역직렬화(Deserializing)할 때 XSS 필터링을 적용하는 커스텀 Deserializer입니다.
      */
-    public static class XssStringJsonDeserializer extends JsonDeserializer<String> {
+    public static class XssStringJsonDeserializer extends JsonDeserializer<String> implements ContextualDeserializer {
 
         // OWASP Sanitizer의 정책을 설정합니다.
         // BLOCKS: 기본적인 블록 요소(p, div, h1-h6 등) 허용
@@ -43,16 +45,56 @@ public class XssSanitizerConfig {
         // LINKS: a 태그와 href 속성 허용 (자동으로 nofollow 처리)
         private static final PolicyFactory POLICY = Sanitizers.BLOCKS
                 .and(Sanitizers.FORMATTING)
+                .and(Sanitizers.STYLES)
                 .and(Sanitizers.LINKS);
+
+        // 이 Deserializer가 XSS 필터링을 수행할지 여부를 결정하는 플래그
+        private boolean enableXssFilter = true;
+
+        // 기본 생성자
+        public XssStringJsonDeserializer() {
+            this.enableXssFilter = true;
+        }
+
+        // 필터링 비활성화를 위한 생성자
+        public XssStringJsonDeserializer(boolean enableXssFilter) {
+            this.enableXssFilter = enableXssFilter;
+        }
 
         @Override
         public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             String value = p.getValueAsString();
-            if (value == null || value.trim().isEmpty()) {
-                return value;
+            if (value == null) {
+                return null;
             }
-            // Sanitizer 정책을 적용하여 잠재적으로 위험한 HTML을 제거합니다.
-            return POLICY.sanitize(value);
+
+            // enableXssFilter 플래그가 true일 때만 Sanitization 수행
+            if (this.enableXssFilter) {
+                return POLICY.sanitize(value);
+            }
+
+            // false일 경우 원본 값 그대로 반환
+            return value;
+        }
+
+        /**
+         * 이 메서드가 Deserializer의 핵심입니다.
+         * Jackson이 필드를 처리하기 전에 호출되며, 필드의 컨텍스트(어노테이션 등)를 보고
+         * 어떤 Deserializer 인스턴스를 사용할지 결정합니다.
+         */
+        @Override
+        public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+            if (property != null) {
+                // 현재 처리 중인 필드에서 @NoXss 어노테이션을 찾습니다.
+                NoXss noXss = property.getAnnotation(NoXss.class);
+
+                // @NoXss 어노테이션이 존재하면, XSS 필터링을 비활성화한 새 Deserializer 인스턴스를 반환합니다.
+                if (noXss != null) {
+                    return new XssStringJsonDeserializer(false);
+                }
+            }
+            // 어노테이션이 없으면, 기본적으로 XSS 필터링을 수행하는 현재 인스턴스를 그대로 사용합니다.
+            return this;
         }
     }
 }

--- a/src/main/java/com/issueDive/dto/LoginRequestDTO.java
+++ b/src/main/java/com/issueDive/dto/LoginRequestDTO.java
@@ -1,5 +1,6 @@
 package com.issueDive.dto;
 
+import com.issueDive.config.NoXss;
 import lombok.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -10,8 +11,10 @@ public class LoginRequestDTO {
 
     @Email(message = "올바른 email이 아닙니다.")
     @NotBlank(message = "email은 필수입니다.")
+    @NoXss
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
+    @NoXss
     private String password;
 }

--- a/src/main/java/com/issueDive/dto/UserRequestDTO.java
+++ b/src/main/java/com/issueDive/dto/UserRequestDTO.java
@@ -1,5 +1,6 @@
 package com.issueDive.dto;
 
+import com.issueDive.config.NoXss;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -14,9 +15,11 @@ public class UserRequestDTO {
 
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     @NotBlank(message = "이메일은 필수입니다.")
+    @NoXss
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하로 입력해주세요.")
+    @NoXss
     private String password;
 }


### PR DESCRIPTION
## 연관된 이슈
> #100

</br>

## 작업 내용
> 최근 도입된 XSS 방어 필터가 이메일, 비밀번호와 같은 필드를 잘못 처리하여 회원가입 및 로그인을 방해하는 버그를 수정합니다. 
- @NoXss라는 커스텀 어노테이션을 도입하고, Jackson Deserializer가 이 어노테이션을 인지하도록 리팩토링했습니다. - 이메일 주소의 @ 기호처럼 보안 필터링에서 제외되어야 하는 필수 특수문자가 HTML 엔티티로 변환되는 것을 막아, @Email과 같은 유효성 검증이 올바르게 동작하도록 하기 위함입니다.

**상세 변경 사항**
1. @NoXss 어노테이션 추가: 특정 필드의 XSS 필터링을 건너뛸 수 있도록 마커 어노테이션을 생성했습니다.
2. XssSantizerConfig 리팩토링: Jackson의 ContextualDeserializer를 구현하여, 필드에 @NoXss 어노테이션이 있는지 여부에 따라 필터링 동작을 동적으로 제어하도록 수정했습니다. 이는 기존 방식보다 훨씬 안정적이고 권장되는 방법입니다.
3. DTO에 @NoXss 적용: UserRequestDTO, LoginRequestDTO의 email 및 password 필드에 @NoXss를 적용하여, 해당 필드들이 더 이상 필터링되지 않도록 조치했습니다.

### PR 유형
> 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
