### PR TITLE
[#108] fix: DTO 유효성 검증 실패 시 전체 에러 메시지가 노출되는 문제 해결

### DIFF
--- a/src/main/java/com/issueDive/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/issueDive/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -78,8 +79,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String errorMessage = (fieldError != null) ? fieldError.getDefaultMessage() : "입력값이 유효하지 않습니다.";
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(ErrorCode.BadRequest, e.getMessage()));
+                .body(ErrorResponse.of(ErrorCode.BadRequest, errorMessage));
     }
 
     @ExceptionHandler(IssueLabelNotFoundException.class)


### PR DESCRIPTION
## 연관된 이슈
> #108 

</br>

## 작업 내용
> DTO 유효성 검증 실패 시 전체 에러 메시지가 노출되는 문제를 해결합니다.
- GlobalExceptionHandler의 handleMethodArgumentNotValid 메서드 수정
    - 첫 번째 필드 에러 정보만 가져와 사용자 친화적인 메시지만 추출하여 응답하도록 변경

### PR 유형
> 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
