### PR TITLE
[#112] feat: 회원가입 성공 시 JWT 토큰을 함께 반환하여 자동 로그인 지원

### DIFF
--- a/src/main/java/com/issueDive/controller/AuthController.java
+++ b/src/main/java/com/issueDive/controller/AuthController.java
@@ -31,13 +31,39 @@ AuthController {
     private final UserService userService;
     private final JwtUtil jwtUtil;
 
-    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @Operation(summary = "회원가입 및 자동 로그인", description = "새로운 사용자를 등록하고, 성공 시 즉시 로그인 처리하여 JWT를 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입 및 자동 로그인 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = JwtResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값 (유효성 검증 실패)", content = @Content),
+            @ApiResponse(responseCode = "409", description = "중복된 이메일", content = @Content)
+    })
+    @PostMapping("/signup")
+    public ResponseEntity<ApiCommonResponse<JwtResponse>> signUp(@RequestBody(description = "회원가입 정보", required = true, content = @Content(schema = @Schema(implementation = UserRequestDTO.class))) @Valid @org.springframework.web.bind.annotation.RequestBody UserRequestDTO request){
+        // 1. 사용자 생성
+        UserResponseDTO user = userService.signUp(request);
+
+        // 2. 생성된 사용자 정보로 즉시 JWT 생성
+        String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
+
+        // 3. 로그인 API와 동일한 JwtResponse 형식으로 응답 구성
+        JwtResponse jwtResponse = JwtResponse.of(
+                accessToken,
+                "Bearer",
+                14400L, // 4시간 (초 단위) : 설정 파일에서 관리하는 것이 더 좋지만 우선은 기존 코드에 맞게 여기서 작성함
+                user
+        );
+
+        ApiCommonResponse<JwtResponse> response = ApiCommonResponse.ok(jwtResponse);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "회원가입 (자동 로그인 없음)", description = "새로운 사용자를 등록만 합니다. (테스트용)")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDTO.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 값 (중복된 이메일 등)", content = @Content)
     })
-    @PostMapping("/signup")
-    public ResponseEntity<ApiCommonResponse<UserResponseDTO>> signUp(@RequestBody(description = "회원가입 정보", required = true, content = @Content(schema = @Schema(implementation = UserRequestDTO.class))) @Valid @org.springframework.web.bind.annotation.RequestBody UserRequestDTO request){
+    @PostMapping("/signup-only")
+    public ResponseEntity<ApiCommonResponse<UserResponseDTO>> signUpOnly(@RequestBody(description = "회원가입 정보", required = true, content = @Content(schema = @Schema(implementation = UserRequestDTO.class))) @Valid @org.springframework.web.bind.annotation.RequestBody UserRequestDTO request){
         UserResponseDTO user = userService.signUp(request);
         ApiCommonResponse<UserResponseDTO> response = ApiCommonResponse.ok(user);
         return new ResponseEntity<>(response, HttpStatus.CREATED);

--- a/src/test/java/com/issueDive/controller/AuthControllerTest.java
+++ b/src/test/java/com/issueDive/controller/AuthControllerTest.java
@@ -68,9 +68,11 @@ public class AuthControllerTest {
                 "password", "password123"
         );
         var responseDto = new UserResponseDTO(1L, "alice", "alice@test.com");
+        var mockToken = "mock-access-token";
 
         // userService.signUp 메서드가 호출될 때 위에서 정의한 DTO를 반환하도록 설정
         given(userService.signUp(any())).willReturn(responseDto);
+        given(jwtUtil.generateAccessToken(anyLong(), anyString())).willReturn(mockToken);
 
         // when & then: API를 호출하고 응답을 검증
         mvc.perform(post("/auth/signup")
@@ -78,8 +80,9 @@ public class AuthControllerTest {
                         .content(om.writeValueAsString(requestBody)))
                 .andExpect(status().isCreated()) // 201 Created 상태 코드 확인
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.username").value("alice"))
-                .andExpect(jsonPath("$.data.email").value("alice@test.com"));
+                .andExpect(jsonPath("$.data.accessToken").value(mockToken))
+                .andExpect(jsonPath("$.data.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.data.user.email").value("alice@test.com"));
     }
 
     @Test


### PR DESCRIPTION
## 연관된 이슈
> #112

</br>

## 작업 내용
> 회원가입 성공 시 JWT 토큰을 함께 반환하여 자동 로그인을 지원하는 기능을 추가했습니다.

- AuthController의 signUp 메서드 로직 수정
- userService.signUp()을 통해 사용자가 성공적으로 생성되면, 해당 사용자 정보를 바탕으로 즉시 jwtUtil.generateAccessToken()을 호출하여 JWT(Access Token) 생성
- signUp 메서드의 API 응답 DTO를 login 메서드와 일치시킴
- Swagger API 문서(/v3/api-docs)의 signUp API 응답 스키마도 수정 반영
- AuthControllerTest의 signUp 테스트 코드 수정

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
