### PR TITLE
[#116] feat: '댓글 많은 순' 정렬 기능 추가

### DIFF
--- a/src/main/java/com/issueDive/dto/IssueFilterRequest.java
+++ b/src/main/java/com/issueDive/dto/IssueFilterRequest.java
@@ -12,7 +12,7 @@ public record IssueFilterRequest(
         List<Long> labelIds,
         @Min(0) Integer page,
         @Min(1) Integer size,
-        @Pattern(regexp = "createdAt|updatedAt") String sort,
+        @Pattern(regexp = "createdAt|updatedAt|commentCount") String sort,
         @Pattern(regexp = "asc|desc|ASC|DESC") String order,
         String query
 ) {}

--- a/src/main/java/com/issueDive/entity/Issue.java
+++ b/src/main/java/com/issueDive/entity/Issue.java
@@ -51,10 +51,10 @@ public class Issue {
     @OneToMany(mappedBy = "issue", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
-    @Column(name = "created_at", updatable = false, insertable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", insertable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     @PrePersist

--- a/src/main/java/com/issueDive/service/IssueService.java
+++ b/src/main/java/com/issueDive/service/IssueService.java
@@ -9,6 +9,7 @@ import com.issueDive.repository.*;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class IssueService {
 
     private final JPAQueryFactory queryFactory;
     private final QIssue qIssue = QIssue.issue;
+    private final QComment qComment = QComment.comment;
     private final IssueRepository issueRepository;
     private final UserRepository userRepository; // 작성자/담당자 유효성 검증용
     private final LabelRepository labelRepository;
@@ -92,17 +94,37 @@ public class IssueService {
     public Page<IssueResponse> getFilteredIssues(IssueFilterRequest filter) {
         BooleanBuilder builder = createFilterBuilder(filter);
         Pageable pageable = createPageable(filter);
-        OrderSpecifier<?> orderSpecifier = getSortOrder(filter.sort(), filter.order());
 
-        // 1. 조건에 맞는 이슈 ID 목록을 먼저 조회 (페이징 적용)
-        List<Long> ids = queryFactory
-                .select(qIssue.id)
-                .from(qIssue)
-                .where(builder)
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(orderSpecifier)
-                .fetch();
+        List<Long> ids;
+
+        // 'commentCount' 정렬일 경우, 별도의 최적화된 쿼리를 사용합니다.
+        if ("commentCount".equalsIgnoreCase(filter.sort())) {
+            Order direction = "desc".equalsIgnoreCase(filter.order()) ? Order.DESC : Order.ASC;
+
+            ids = queryFactory
+                    .select(qIssue.id)
+                    .from(qIssue)
+                    .leftJoin(qIssue.comments, qComment) // comment 테이블과 JOIN
+                    .where(builder)
+                    .groupBy(qIssue.id) // issue ID로 그룹화
+                    .orderBy(qComment.count().as("comment_count").castToNum(Long.class).desc()) // 댓글 개수로 정렬
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
+        }
+        else { // 그 외의 정렬은 기존 방식을 사용
+
+            // 1. 조건에 맞는 이슈 ID 목록을 먼저 조회 (페이징 적용)
+            OrderSpecifier<?> orderSpecifier = getSortOrder(filter.sort(), filter.order());
+            ids = queryFactory
+                    .select(qIssue.id)
+                    .from(qIssue)
+                    .where(builder)
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .orderBy(orderSpecifier)
+                    .fetch();
+        }
 
         if (ids.isEmpty()) {
             return new PageImpl<>(Collections.emptyList(), pageable, 0);
@@ -112,10 +134,10 @@ public class IssueService {
         List<Issue> issues = issueRepository.findAllByIdInWithDetails(ids);
 
         // 정렬 유지를 위해 ID 목록 순서대로 다시 정렬
-        List<Issue> sortedIssues = ids.stream()
-                .flatMap(id -> issues.stream().filter(issue -> issue.getId().equals(id)))
-                .distinct()
-                .collect(Collectors.toList());
+        List<Long> finalIds = ids;
+        List<Issue> sortedIssues = issues.stream()
+                .sorted((i1, i2) -> Integer.compare(finalIds.indexOf(i1.getId()), finalIds.indexOf(i2.getId())))
+                .toList();
 
         // 3. 전체 카운트 조회
         long total = queryFactory


### PR DESCRIPTION
## 연관된 이슈
> #116 

</br>

## 작업 내용
> 사용자가 댓글이 많이 달린 이슈를 우선적으로 탐색할 수 있도록 'Most commented' 정렬 기능을 추가합니다.

1. IssueFilterRequest.java: 
sort 필드의 @Pattern 유효성 검증에 commentCount를 추가하여, API가 해당 정렬 값을 받을 수 있도록 허용했습니다.

2. IssueService.java:
commentCount 정렬 요청 시, 데이터베이스 성능 저하를 유발할 수 있는 비효율적인 서브쿼리 방식(comments.size()) 대신, LEFT JOIN과 GROUP BY를 사용하는 최적화된 QueryDSL 쿼리를 구현하여, 데이터가 증가하더라도 안정적인 정렬 성능을 보장하도록 리팩토링했습니다.

### 📸 스크린샷 (선택)

### PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
