### PR TITLE
[#91]:feat:테스트시에 redis연결을 시도해서 Redis 비활성화

### DIFF
--- a/src/test/java/com/issueDive/config/SecurityConfigTest.java
+++ b/src/test/java/com/issueDive/config/SecurityConfigTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -65,9 +64,6 @@ public class SecurityConfigTest {
 
     @MockitoBean  // 이미 있을 것
     private TokenBlacklistService tokenBlacklistService;
-
-    @MockitoBean  // 이 줄을 추가하세요
-    private StringRedisTemplate stringRedisTemplate;
 
     private static final String VALID_TOKEN = "valid.jwt.token";
     private static final String USER_EMAIL = "test@example.com";

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -35,3 +35,9 @@ spring.flyway.enabled=false
 # ??? ???? ??? SQL ??? ??? ??? ?
 # =================================================================
  spring.flyway.validate-on-migrate=false
+
+# =================================================================
+# Redis 설정 (테스트 환경에서 Redis 비활성화)
+# =================================================================
+# Redis 자동 구성 비활성화 (테스트에서 실제 Redis 연결 방지)
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration


### PR DESCRIPTION
## 연관된 이슈
> #91 

</br>

## 작업 내용
> 테스트시에 redis연결을 시도해서 Redis 비활성화 </br>
> application-test.properties에서 redis 자동 구성 비활성화  코드 추가spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration</br>

### 📸 스크린샷 (선택)

### PR 유형
> 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

</br>

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

</br>

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] `main` branch가 아닌 `dev` branch에 PR 요청을 했습니다. (main branch에 바로 PR&merge하지 않기).
